### PR TITLE
Update Coreuser serializer

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -24,7 +24,6 @@ class CoreUser(DjangoModelFactory):
         django_get_or_create = ('user',)
 
     user = SubFactory(User)
-    name = LazyAttribute(lambda o: o.user.first_name + " " + o.user.last_name)
     organization = SubFactory(Organization)
 
 

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -57,10 +57,10 @@ class CoreUserSerializer(serializers.ModelSerializer):
     first_name = serializers.CharField(source='user.first_name')
     last_name = serializers.CharField(source='user.last_name')
     email = serializers.EmailField(source='user.email')
-    username = serializers.CharField(source='user.username', write_only=True)
+    username = serializers.CharField(source='user.username')
     password = serializers.CharField(source='user.password', write_only=True)
     is_active = serializers.BooleanField(source='user.is_active',
-                                         required=False, write_only=True)
+                                         required=False)
     organization_name = serializers.CharField(source='organization.name',
                                               write_only=True)
 


### PR DESCRIPTION
## Purpose
@aziz-haddad requested that `username` and `active` info are returned back in CoreUser responses.

## Approach
- Just removed the write-only parameter from the fields.