### PR TITLE
Add authorization to Bifrost aggregated data - PLAT-202

### DIFF
--- a/gateway/tests/test_utils.py
+++ b/gateway/tests/test_utils.py
@@ -2,12 +2,69 @@
 DJANGO_SETTINGS_MODULE=bifrost-api.settings.production py.test gateway/tests/test_utils.py -v --cov
 or: pytest gateway/tests/test_utils.py
 """
-
 import uuid
 import datetime
 import pytest
 
-from gateway import utils
+import factories
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+
+from gateway.exceptions import GatewayError
+from gateway.views import APIGatewayView
+from gateway.utils import json_dump, validate_object_access
+
+
+class UtilsValidateBifrostObjectAccessTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.core_user = factories.CoreUser()
+
+    def get_mock_request(self, url, view, user=None):
+        request = self.factory.get(url)
+        if user is not None:
+            request.user = user
+            force_authenticate(request, user=user)
+        request = view().initialize_request(request)
+        return request
+
+    def test_validate_bifrost_wfl1_access_superuser(self):
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
+
+        request = self.get_mock_request('/', APIGatewayView,
+                                        self.core_user.user)
+        wflvl1 = factories.WorkflowLevel1(
+            organization=self.core_user.organization)
+        validate_object_access(request, wflvl1)
+
+    def test_validate_bifrost_wfl1_no_permission(self):
+        request = self.get_mock_request('/', APIGatewayView,
+                                        self.core_user.user)
+        wflvl1 = factories.WorkflowLevel1()
+
+        error_message = 'You do not have permission to perform this action.'
+        with self.assertRaisesMessage(PermissionDenied, error_message):
+            validate_object_access(request, wflvl1)
+
+    def test_validate_bifrost_wfl1_not_authenticated_user(self):
+        request = self.get_mock_request('/', APIGatewayView)
+        wflvl1 = factories.WorkflowLevel1()
+
+        error_message = 'Authentication credentials were not provided.'
+        with self.assertRaisesMessage(NotAuthenticated, error_message):
+            validate_object_access(request, wflvl1)
+
+    def test_validate_bifrost_logic_module_no_viewset(self):
+        request = self.get_mock_request('/', APIGatewayView,
+                                        self.core_user.user)
+        lm = factories.LogicModule()
+
+        with self.assertRaises(GatewayError):
+            validate_object_access(request, lm)
 
 
 def test_json_dump():
@@ -18,7 +75,7 @@ def test_json_dump():
         "uuid": uuid.UUID('50096bc6-848a-456f-ad36-3ac04607ff67'),
         "datetime": datetime.datetime(2019, 2, 5, 12, 36, 0, 147972)
     }
-    response = utils.json_dump(obj)
+    response = json_dump(obj)
     expected_response = '{"string": "test1234",' \
                         ' "integer": 123,' \
                         ' "array": ["1", 2],' \
@@ -35,6 +92,6 @@ def test_json_dump_exception():
     test_obj = TestObj()
 
     with pytest.raises(TypeError) as exc:
-        utils.json_dump(test_obj)
+        json_dump(test_obj)
 
     assert 'is not handled' in str(exc.value)

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -208,6 +208,7 @@ class APIGatewayView(views.APIView):
                     except cls.DoesNotExist as e:
                         logger.info(e)
                     else:
+                        utils.validate_object_access(request, obj)
                         data = model_to_dict(obj)
             else:
                 app = self._load_swagger_resource(
@@ -286,7 +287,6 @@ class APIGatewayView(views.APIView):
                 kwargs['pk'] is None):
             raise exceptions.RequestValidationError(
                 'The object ID is missing.', 400)
-
 
     def _get_swagger_data(self, request):
         """

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 from django.utils.deprecation import MiddlewareMixin
 from django.http import JsonResponse
@@ -22,6 +23,6 @@ class ExceptionMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, exception):
         if isinstance(exception, PermissionDenied):
-            return JsonResponse(data=exception.content,
+            return JsonResponse(data=json.loads(exception.content),
                                 status=exception.status)
         return None


### PR DESCRIPTION
## Purpose

When we need to aggregate data from Bifrost, the application accesses the database directly, in order to retrieve the needed data. We need to make sure the user who is requesting the data is allowed to see it, in other words, we need to validate user permissions.

Related: https://humanitec.atlassian.net/browse/PLAT-202