### PR TITLE
Fix encoding responses is removing UUIDs - PLAT-243

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ pipeline:
       - apk add --no-cache bash git python-dev gcc musl-dev postgresql-dev libffi-dev libressl-dev
       - pip install -r requirements/ci.txt --no-cache-dir
       - ./tcp-port-wait.sh postgres 5432
-      - python manage.py test gateway.tests # TODO make all tests run
+      - DJANGO_SETTINGS_MODULE=bifrost-api.settings.base py.test gateway/tests -v --cov  # TODO make all tests run
     when:
       event: [pull_request, push, tag]
     environment:

--- a/gateway/tests/test_data_mesh.py
+++ b/gateway/tests/test_data_mesh.py
@@ -307,8 +307,8 @@ class DataMeshTest(TestCase):
             'contact_uuid': 1
         }
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), json.dumps(
-            expected_data, default=utils.datetime_handler))
+        self.assertEqual(response.content.decode('utf-8'),
+                         utils.json_dump(expected_data))
 
     @patch('gateway.views.APIGatewayView._load_swagger_resource')
     @patch('gateway.views.APIGatewayView._perform_service_request')

--- a/gateway/tests/test_utils.py
+++ b/gateway/tests/test_utils.py
@@ -1,0 +1,40 @@
+"""pytest unit tests, to run:
+DJANGO_SETTINGS_MODULE=bifrost-api.settings.production py.test gateway/tests/test_utils.py -v --cov
+or: pytest gateway/tests/test_utils.py
+"""
+
+import uuid
+import datetime
+import pytest
+
+from gateway import utils
+
+
+def test_json_dump():
+    obj = {
+        "string": "test1234",
+        "integer": 123,
+        "array": ['1', 2, ],
+        "uuid": uuid.UUID('50096bc6-848a-456f-ad36-3ac04607ff67'),
+        "datetime": datetime.datetime(2019, 2, 5, 12, 36, 0, 147972)
+    }
+    response = utils.json_dump(obj)
+    expected_response = '{"string": "test1234",' \
+                        ' "integer": 123,' \
+                        ' "array": ["1", 2],' \
+                        ' "uuid": "50096bc6-848a-456f-ad36-3ac04607ff67",' \
+                        ' "datetime": "2019-02-05T12:36:00.147972"}'
+    assert response == expected_response
+
+
+def test_json_dump_exception():
+
+    class TestObj(object):
+        pass
+
+    test_obj = TestObj()
+
+    with pytest.raises(TypeError) as exc:
+        utils.json_dump(test_obj)
+
+    assert 'is not handled' in str(exc.value)

--- a/gateway/utils.py
+++ b/gateway/utils.py
@@ -1,6 +1,12 @@
+from uuid import UUID
+
 import datetime
 import re
+import json
 import requests
+
+from pyswagger.primitives.comm import PrimJSONEncoder
+
 
 from . import exceptions
 from . import models as gtm
@@ -56,10 +62,21 @@ def get_swagger_from_url(api_url: str):
             f'Please, check that {api_url} is accessible.') from error
 
 
-def datetime_handler(obj):
+def obj_to_json_default_handler(obj):
     """
     JSON doesn't have a default datetime type, so this is why Python can't
     handle it automatically. So you need to make the datetime into a string.
     """
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    if isinstance(obj, UUID):
+        return obj.__str__()
+    raise TypeError("Object of type '%s' is not handled and JSON serialized "
+                    "yet" % obj.__class__.__name__)
+
+
+def json_dump(obj):
+    """Serialize ``obj`` to a JSON formatted ``str``."""
+    return json.dumps(obj,
+                      cls=PrimJSONEncoder,
+                      default=obj_to_json_default_handler)

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from urllib.error import URLError
@@ -15,7 +14,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from pyswagger import App
 from pyswagger.contrib.client.requests import Client
 from pyswagger.io import Response as PySwaggerResponse
-from pyswagger.primitives.comm import PrimJSONEncoder
 
 from workflow.permissions import IsSuperUser
 
@@ -128,9 +126,8 @@ class APIGatewayView(views.APIView):
             except exceptions.ServiceDoesNotExist as e:
                 logger.error(e.content)
 
-        content = json.dumps(response.data,
-                             cls=PrimJSONEncoder,
-                             default=utils.datetime_handler)
+        content = utils.json_dump(response.data)
+
         return HttpResponse(content=content,
                             status=response.status,
                             content_type='application/json')

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -2,3 +2,6 @@
 
 coverage==4.5.1
 flake8==3.5.0
+pytest==4.1.1
+pytest-django==3.4.5
+pytest-cov==2.6.1


### PR DESCRIPTION
Current behaviour: When users send a request to fetch data and it includes UUID, the API Gateway is replacing the UUID by `null`

Expected behaviour: When a user sends a request to retrieve data, the gateway shouldn't replace UUIDs by `null` but keep it instead. In case, the aggregation flag was used and then UUIDs will be replaced by the object data related to the UUID.

Related Ticket: https://humanitec.atlassian.net/browse/PLAT-243