### PR TITLE
Remove unused PrimJSONEncoder - PLAT-243

### DIFF
--- a/gateway/tests/test_data_mesh.py
+++ b/gateway/tests/test_data_mesh.py
@@ -311,7 +311,8 @@ class DataMeshTest(TestCase):
         }
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode('utf-8'),
-                         utils.json_dump(expected_data))
+                         json.dumps(expected_data,
+                                    cls=utils.GatewayJSONEncoder))
 
     @patch('gateway.views.APIGatewayView._load_swagger_resource')
     @patch('gateway.views.APIGatewayView._perform_service_request')

--- a/gateway/tests/test_utils.py
+++ b/gateway/tests/test_utils.py
@@ -2,9 +2,10 @@
 DJANGO_SETTINGS_MODULE=bifrost-api.settings.production py.test gateway/tests/test_utils.py -v --cov
 or: pytest gateway/tests/test_utils.py
 """
-import uuid
 import datetime
+import json
 import pytest
+import uuid
 
 import factories
 
@@ -13,8 +14,8 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 
 from gateway.exceptions import GatewayError
+from gateway.utils import GatewayJSONEncoder, validate_object_access
 from gateway.views import APIGatewayView
-from gateway.utils import json_dump, validate_object_access
 
 
 class UtilsValidateBifrostObjectAccessTest(TestCase):
@@ -75,7 +76,8 @@ def test_json_dump():
         "uuid": uuid.UUID('50096bc6-848a-456f-ad36-3ac04607ff67'),
         "datetime": datetime.datetime(2019, 2, 5, 12, 36, 0, 147972)
     }
-    response = json_dump(obj)
+
+    response = json.dumps(obj, cls=GatewayJSONEncoder)
     expected_response = '{"string": "test1234",' \
                         ' "integer": 123,' \
                         ' "array": ["1", 2],' \
@@ -90,8 +92,9 @@ def test_json_dump_exception():
         pass
 
     test_obj = TestObj()
+    error_message = 'Object of type \'TestObj\' is not JSON serializable'
 
     with pytest.raises(TypeError) as exc:
-        json_dump(test_obj)
+        json.dumps(test_obj, cls=GatewayJSONEncoder)
 
-    assert 'is not handled' in str(exc.value)
+    assert error_message in str(exc.value)

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from urllib.error import URLError
@@ -126,7 +127,8 @@ class APIGatewayView(views.APIView):
             except exceptions.ServiceDoesNotExist as e:
                 logger.error(e.content)
 
-        content = utils.json_dump(response.data)
+        content = json.dumps(response.data,
+                             cls=utils.GatewayJSONEncoder)
 
         return HttpResponse(content=content,
                             status=response.status,


### PR DESCRIPTION
Fixes the bug with unhandled Primitives. Actually the `PrimJSONEncoder` - class was never called from `json.dumps()`:
```
def dumps(obj, *, skipkeys=False, ensure_ascii=True, check_circular=True,
        allow_nan=True, cls=None, indent=None, separators=None,
        default=None, sort_keys=False, **kw):
    if (not skipkeys and ensure_ascii and
        check_circular and allow_nan and
        cls is None and indent is None and separators is None and
        default is None and not sort_keys and not kw):
        return _default_encoder.encode(obj)
    if cls is None:
        cls = JSONEncoder
    return cls(
        skipkeys=skipkeys, ensure_ascii=ensure_ascii,
        check_circular=check_circular, allow_nan=allow_nan, indent=indent,
        separators=separators, default=default, sort_keys=sort_keys,
        **kw).encode(obj)
```