### PR TITLE
 Rename user_uuid to core_user_uuid in jwt_enricher - PLAT-146

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ pipeline:
       - pip install -r requirements/ci.txt --no-cache-dir
       - ./tcp-port-wait.sh postgres 5432
       - DJANGO_SETTINGS_MODULE=bifrost-api.settings.base pytest gateway/tests -v --cov  # TODO make all tests run
+      - DJANGO_SETTINGS_MODULE=bifrost-api.settings.base pytest workflow/tests/test_jwt_utils.py -v --cov
     when:
       event: [pull_request, push, tag]
     environment:

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -62,10 +62,8 @@ done
 
 set -o xtrace  # shows what's being executed
 
-if [ "$keepdb" = false ] ; then
-    apk add git
-    pip install -r requirements/test.txt
-fi
+apk add git
+pip install -r requirements/test.txt
 
 if [ "$ci" = true ] ; then
     cat .flake8
@@ -89,9 +87,9 @@ if [ "$ci" = true ] ; then
     coverage report -m
 else
     if [ "$keepdb" = true ] ; then
-        pytest --log-level=2 --pdb --pdbcls=IPython.terminal.debugger:Pdb -s --reuse-db
+        pytest --log-level=2 --pdb --pdbcls=IPython.terminal.debugger:Pdb --reuse-db
     else
-        pytest --log-level=2 --pdb --pdbcls=IPython.terminal.debugger:Pdb -s
+        pytest --log-level=2 --pdb --pdbcls=IPython.terminal.debugger:Pdb
     fi
     if [ $? -eq 1 ] && [ "$bash_on_finish" = true ]; then
         bash_on_failure

--- a/workflow/jwt_utils.py
+++ b/workflow/jwt_utils.py
@@ -17,7 +17,7 @@ def payload_enricher(request):
             logger.error('No matching CoreUser found.')
             raise PermissionDenied('No matching CoreUser found.')
         return {
-            'user_uuid': user['core_user_uuid'],
+            'core_user_uuid': user['core_user_uuid'],
             'organization_uuid': user['organization__organization_uuid'],
         }
     else:

--- a/workflow/tests/test_jwt_utils.py
+++ b/workflow/tests/test_jwt_utils.py
@@ -10,13 +10,12 @@ from workflow.models import ROLE_ORGANIZATION_ADMIN
 class JWTUtilsTest(TestCase):
     def test_jwt_payload_enricher(self):
         rf = RequestFactory()
-        tola_user = factories.CoreUser()
-        request = rf.post('', {'username': tola_user.user.username})
+        core_user = factories.CoreUser()
+        request = rf.post('', {'username': core_user.user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'user_uuid': str(tola_user.tola_user_uuid),
-            'organization_uuid': str(tola_user.organization.organization_uuid),
-            'role': None
+            'core_user_uuid': str(core_user.core_user_uuid),
+            'organization_uuid': str(core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)
 
@@ -28,29 +27,28 @@ class JWTUtilsTest(TestCase):
 
     def test_jwt_payload_enricher_superuser(self):
         rf = RequestFactory()
-        tola_user = factories.CoreUser()
-        tola_user.user.is_superuser = True
-        tola_user.user.save()
+        core_user = factories.CoreUser()
+        core_user.user.is_superuser = True
+        core_user.user.save()
 
-        request = rf.post('', {'username': tola_user.user.username})
+        request = rf.post('', {'username': core_user.user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'user_uuid': str(tola_user.tola_user_uuid),
-            'organization_uuid': str(tola_user.organization.organization_uuid),
+            'core_user_uuid': str(core_user.core_user_uuid),
+            'organization_uuid': str(core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)
 
     def test_jwt_payload_enricher_org_admin(self):
         rf = RequestFactory()
-        tola_user = factories.CoreUser()
+        core_user = factories.CoreUser()
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        tola_user.user.groups.add(group_org_admin)
+        core_user.user.groups.add(group_org_admin)
 
-        request = rf.post('', {'username': tola_user.user.username})
+        request = rf.post('', {'username': core_user.user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'user_uuid': str(tola_user.tola_user_uuid),
-            'organization_uuid': str(tola_user.organization.organization_uuid),
-            'role': ROLE_ORGANIZATION_ADMIN
+            'core_user_uuid': str(core_user.core_user_uuid),
+            'organization_uuid': str(core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)


### PR DESCRIPTION
The `user_uuid` refers to the `CoreUser` and its `core_user_uuid`, what creates confusion. So it should be renamed in the JWT Token before other applications register to Walhall.