### PR TITLE
Clear exception for endpoint not found

### DIFF
--- a/gateway/views.py
+++ b/gateway/views.py
@@ -4,7 +4,7 @@ import logging
 from urllib.error import URLError
 
 from django.forms.models import model_to_dict
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse
 from django.http.request import QueryDict
 from rest_framework import permissions, views, viewsets
 from rest_framework.authentication import get_authorization_header
@@ -408,7 +408,7 @@ class APIGatewayView(views.APIView):
         try:
             req, resp = self._get_req_and_rep(app, request, **kwargs)
         except exceptions.EndpointNotFound:
-            raise Http404()
+            raise exceptions.GatewayError('Endpoint not found.', status=404)
 
         headers = self._get_service_request_headers(request)
         try:

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -4,7 +4,7 @@ import json
 from django.utils.deprecation import MiddlewareMixin
 from django.http import JsonResponse
 
-from gateway.exceptions import PermissionDenied
+from gateway.exceptions import PermissionDenied, GatewayError
 
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ class ExceptionMiddleware(MiddlewareMixin):
 
     @staticmethod
     def process_exception(request, exception):
-        if isinstance(exception, PermissionDenied):
+        if isinstance(exception, (PermissionDenied, GatewayError)):
             return JsonResponse(data=json.loads(exception.content),
                                 status=exception.status)
         return None


### PR DESCRIPTION
Instead of just returning a 404 with {'detail':'Not found'} what could
also mean that the object is not found, we return now a clear message,
if the endpoint was not found.