### PR TITLE
PLAT-160: fix tests for portfolio, change tola_user to core_user

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -1,4 +1,4 @@
-from factory import DjangoModelFactory, LazyAttribute, SubFactory
+from factory import DjangoModelFactory, SubFactory
 
 from workflow.models import (
     CoreUser as CoreUserM,
@@ -6,7 +6,8 @@ from workflow.models import (
     WorkflowLevel1 as WorkflowLevel1M,
     WorkflowLevel2 as WorkflowLevel2M,
     WorkflowTeam as WorkflowTeamM,
-    WorkflowLevel2Sort as WorkflowLevel2SortM
+    WorkflowLevel2Sort as WorkflowLevel2SortM,
+    Portfolio as PortfolioM,
 )
 from .django_models import User, Group
 
@@ -58,3 +59,10 @@ class WorkflowLevel2Sort(DjangoModelFactory):
 
     workflowlevel1 = SubFactory(WorkflowLevel1)
     workflowlevel2_parent_id = SubFactory(WorkflowLevel2)
+
+
+class Portfolio(DjangoModelFactory):
+    class Meta:
+        model = PortfolioM
+
+    organization = SubFactory(Organization)

--- a/workflow/tests/test_browseableapi.py
+++ b/workflow/tests/test_browseableapi.py
@@ -6,25 +6,25 @@ from rest_framework.test import APIClient
 class BrowsableAPITest(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_login_superuser(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.set_password('1234')
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.set_password('1234')
+        self.core_user.user.save()
 
-        self.client.login(username=self.tola_user.user.username,
+        self.client.login(username=self.core_user.user.username,
                           password='1234')
         response = self.client.get('/api/docs/')
 
         self.assertEqual(response.status_code, 200)
 
     def test_login_normaluser(self):
-        self.tola_user.user.set_password('1234')
-        self.tola_user.user.save()
+        self.core_user.user.set_password('1234')
+        self.core_user.user.save()
 
-        self.client.login(username=self.tola_user.user.username,
+        self.client.login(username=self.core_user.user.username,
                           password='1234')
         response = self.client.get('/api/docs/')
 

--- a/workflow/tests/test_internationalizationview.py
+++ b/workflow/tests/test_internationalizationview.py
@@ -12,15 +12,15 @@ class InternationalizationListViewTest(TestCase):
     def setUp(self):
         factories.Internationalization()
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_list_internationalization_superuser(self):
         """
         Superusers are able to list all the objects
         """
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         request = self.factory.get('/api/internationalization/')
         view = InternationalizationViewSet.as_view({'get': 'list'})
@@ -33,7 +33,7 @@ class InternationalizationListViewTest(TestCase):
         Normal users are able to list all the objects
         """
         request = self.factory.get('/api/internationalization/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
@@ -42,23 +42,23 @@ class InternationalizationListViewTest(TestCase):
 
 class InternationalizationCreateViewTest(TestCase):
     def setUp(self):
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         self.factory = APIRequestFactory()
 
     def test_create_internationalization_superuser(self):
         """
         Superusers are able to create new translations
         """
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         data = {
             u'language': u'pt-BR',
             u'language_file': u'{"name": "Nome", "gender": "Gênero"}'
         }
         request = self.factory.post('/api/internationalization/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'post': 'create'})
         response = view(request)
 
@@ -74,7 +74,7 @@ class InternationalizationCreateViewTest(TestCase):
             u'language_file': u'{"name": "Nome", "gender": "Gênero"}'
         }
         request = self.factory.post('/api/internationalization/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'post': 'create'})
         response = view(request)
 
@@ -83,12 +83,12 @@ class InternationalizationCreateViewTest(TestCase):
 
 class InternationalizationRetrieveViewsTest(TestCase):
     def setUp(self):
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         self.factory = APIRequestFactory()
 
     def test_retrieve_unexisting_internationalization(self):
         request = self.factory.get('/api/internationalization/1111')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'get': 'retrieve'})
         response = view(request, pk=1111)
         self.assertEqual(response.status_code, 404)
@@ -97,14 +97,14 @@ class InternationalizationRetrieveViewsTest(TestCase):
         """
         Superusers are able to retrieve any translation
         """
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
         inter = factories.Internationalization()
 
         request = self.factory.get('/api/internationalization/{}'.format(
             inter.id))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'get': 'retrieve'})
         response = view(request, pk=inter.pk)
         self.assertEqual(response.status_code, 200)
@@ -118,7 +118,7 @@ class InternationalizationRetrieveViewsTest(TestCase):
 
         request = self.factory.get('/api/internationalization/{}'.format(
             inter.id))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'get': 'retrieve'})
         response = view(request, pk=inter.pk)
         self.assertEqual(response.status_code, 200)
@@ -127,19 +127,19 @@ class InternationalizationRetrieveViewsTest(TestCase):
 
 class InternationalizationUpdateViewTest(TestCase):
     def setUp(self):
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         self.factory = APIRequestFactory()
 
     def test_update_unexisting_internationalization(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         data = {
             u'language': u'pt-BR',
         }
         request = self.factory.post('/api/internationalization/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'post': 'update'})
         response = view(request, pk=999)
 
@@ -149,9 +149,9 @@ class InternationalizationUpdateViewTest(TestCase):
         """
         Superusers are able to update translations
         """
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
         inter = factories.Internationalization()
 
         data = {
@@ -159,7 +159,7 @@ class InternationalizationUpdateViewTest(TestCase):
             u'language_file': u'{"name": "Nome", "gender": "Gênero"}'
         }
         request = self.factory.post('/api/internationalization/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'post': 'update'})
         response = view(request, pk=inter.pk)
 
@@ -176,7 +176,7 @@ class InternationalizationUpdateViewTest(TestCase):
             u'language': u'pt-BR',
         }
         request = self.factory.post('/api/internationalization/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'post': 'update'})
         response = view(request, pk=inter.pk)
 
@@ -185,16 +185,16 @@ class InternationalizationUpdateViewTest(TestCase):
 
 class InternationalizationDeleteViewTest(TestCase):
     def setUp(self):
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         self.factory = APIRequestFactory()
 
     def test_delete_unexisting_internationalization(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         request = self.factory.delete('/api/internationalization/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=999)
 
@@ -204,13 +204,13 @@ class InternationalizationDeleteViewTest(TestCase):
         """
         Superusers are able to delete any translation
         """
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
         inter = factories.Internationalization()
 
         request = self.factory.delete('/api/internationalization/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=inter.pk)
 
@@ -226,7 +226,7 @@ class InternationalizationDeleteViewTest(TestCase):
         inter = factories.Internationalization()
 
         request = self.factory.delete('/api/internationalization/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=inter.pk)
 
@@ -236,7 +236,7 @@ class InternationalizationDeleteViewTest(TestCase):
 class InternationalizationFilterViewTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_filter_internationalization_by_language(self):
         """
@@ -249,7 +249,7 @@ class InternationalizationFilterViewTest(TestCase):
         url = '/api/internationalization/?{}'.format(query_string)
 
         request = self.factory.get(url)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = InternationalizationViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)

--- a/workflow/tests/test_milestoneview.py
+++ b/workflow/tests/test_milestoneview.py
@@ -14,7 +14,7 @@ class MilestoneListViewsTest(TestCase):
     def setUp(self):
         factories.Milestone.create_batch(2)
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_list_milestone_superuser(self):
         request = self.factory.get('/api/milestone/')
@@ -28,15 +28,15 @@ class MilestoneListViewsTest(TestCase):
     def test_list_milestone_org_admin(self):
         request = self.factory.get('/api/milestone/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        self.tola_user.user.groups.add(group_org_admin)
+        self.core_user.user.groups.add(group_org_admin)
 
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = MilestoneViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.Milestone(organization=self.tola_user.organization)
+        factories.Milestone(organization=self.core_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
@@ -44,15 +44,15 @@ class MilestoneListViewsTest(TestCase):
     def test_list_milestone_program_admin(self):
         request = self.factory.get('/api/milestone/')
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = MilestoneViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.Milestone(organization=self.tola_user.organization)
+        factories.Milestone(organization=self.core_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
@@ -60,15 +60,15 @@ class MilestoneListViewsTest(TestCase):
     def test_list_milestone_program_team(self):
         request = self.factory.get('/api/milestone/')
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = MilestoneViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.Milestone(organization=self.tola_user.organization)
+        factories.Milestone(organization=self.core_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
@@ -76,15 +76,15 @@ class MilestoneListViewsTest(TestCase):
     def test_list_milestone_view_only(self):
         request = self.factory.get('/api/milestone/')
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = MilestoneViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.Milestone(organization=self.tola_user.organization)
+        factories.Milestone(organization=self.core_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)

--- a/workflow/tests/test_organizationview.py
+++ b/workflow/tests/test_organizationview.py
@@ -46,11 +46,11 @@ class OrganizationSubscriptionViewTest(TestCase):
 
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_get_subscription(self):
-        self.tola_user.organization.chargebee_subscription_id = 12345
-        self.tola_user.organization.save()
+        self.core_user.organization.chargebee_subscription_id = 12345
+        self.core_user.organization.save()
 
         sub_response = self.SubscriptionTest({})
         plan_response = self.PlanTest({'name': 'Plan test'})
@@ -58,9 +58,9 @@ class OrganizationSubscriptionViewTest(TestCase):
         Plan.retrieve = Mock(return_value=plan_response)
 
         request = self.factory.get('')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = OrganizationViewSet.as_view({'get': 'subscription'})
-        response = view(request, pk=self.tola_user.organization.id)
+        response = view(request, pk=self.core_user.organization.id)
         plan = response.data['plan']
         subscription = response.data
 
@@ -71,8 +71,8 @@ class OrganizationSubscriptionViewTest(TestCase):
         self.assertEqual(subscription['total_seats'], 1)
 
     def test_get_subscription_error(self):
-        self.tola_user.organization.chargebee_subscription_id = 12345
-        self.tola_user.organization.save()
+        self.core_user.organization.chargebee_subscription_id = 12345
+        self.core_user.organization.save()
 
         json_obj = {
             'message': "Sorry, we couldn't find that resource",
@@ -83,24 +83,24 @@ class OrganizationSubscriptionViewTest(TestCase):
         Subscription.retrieve = Mock(side_effect=sub_response)
 
         request = self.factory.get('')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = OrganizationViewSet.as_view({'get': 'subscription'})
-        response = view(request, pk=self.tola_user.organization.id)
+        response = view(request, pk=self.core_user.organization.id)
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.data['detail'], 'No subscription was found.')
 
     def test_get_subscription_id_exception(self):
-        self.tola_user.organization.chargebee_subscription_id = 12345
-        self.tola_user.organization.save()
+        self.core_user.organization.chargebee_subscription_id = 12345
+        self.core_user.organization.save()
 
         sub_response = Exception("Id is None or empty")
         Subscription.retrieve = Mock(side_effect=sub_response)
 
         request = self.factory.get('')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = OrganizationViewSet.as_view({'get': 'subscription'})
-        response = view(request, pk=self.tola_user.organization.id)
+        response = view(request, pk=self.core_user.organization.id)
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.data['detail'], 'No subscription was found.')

--- a/workflow/tests/test_workflowlevel2sortview.py
+++ b/workflow/tests/test_workflowlevel2sortview.py
@@ -13,7 +13,7 @@ class WorkflowLevel2SortListViewsTest(TestCase):
     def setUp(self):
         factories.WorkflowLevel2Sort.create_batch(2)
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
 
     def test_list_workflowlevel2sort_superuser(self):
         """
@@ -33,20 +33,20 @@ class WorkflowLevel2SortListViewsTest(TestCase):
         """
         request = self.factory.get('/workflowlevel2sort/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        self.tola_user.user.groups.add(group_org_admin)
+        self.core_user.user.groups.add(group_org_admin)
 
         wflvl1 = factories.WorkflowLevel1()
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             workflowlevel1=wflvl1)
         factories.WorkflowLevel2Sort(workflowlevel1=wflvl1)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        wflvl1.organization = self.tola_user.organization
+        wflvl1.organization = self.core_user.organization
         wflvl1.save()
         response = view(request)
         self.assertEqual(response.status_code, 200)
@@ -59,12 +59,12 @@ class WorkflowLevel2SortListViewsTest(TestCase):
         """
         request = self.factory.get('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             workflowlevel1=wflvl1,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
@@ -82,12 +82,12 @@ class WorkflowLevel2SortListViewsTest(TestCase):
         """
         request = self.factory.get('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             workflowlevel1=wflvl1,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
@@ -105,12 +105,12 @@ class WorkflowLevel2SortListViewsTest(TestCase):
         """
         request = self.factory.get('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
         WorkflowTeam.objects.create(
-            workflow_user=self.tola_user,
+            workflow_user=self.core_user,
             workflowlevel1=wflvl1,
             role=factories.Group(name=ROLE_VIEW_ONLY))
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
@@ -125,13 +125,13 @@ class WorkflowLevel2SortListViewsTest(TestCase):
 class WorkflowLevel2SortCreateViewsTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         factories.Group()
 
     def test_create_workflowlevel2_superuser(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         request = self.factory.post('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1()
@@ -140,7 +140,7 @@ class WorkflowLevel2SortCreateViewsTest(TestCase):
                 'workflowlevel1': wflvl1.pk}
 
         request = self.factory.post('/workflowlevel2/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'create'})
         response = view(request)
 
@@ -150,13 +150,13 @@ class WorkflowLevel2SortCreateViewsTest(TestCase):
     def test_create_workflowlevel2sort_normal_user(self):
         request = self.factory.post('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
 
         data = {'workflowlevel2_id': 1,
                 'workflowlevel1': wflvl1.pk}
 
         request = self.factory.post('/workflowlevel2/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'create'})
         response = view(request)
 
@@ -167,25 +167,25 @@ class WorkflowLevel2SortCreateViewsTest(TestCase):
 class WorkflowLevel2SortUpdateViewsTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         factories.Group()
 
     def test_update_unexisting_workflowlevel2sort(self):
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        self.tola_user.user.groups.add(group_org_admin)
+        self.core_user.user.groups.add(group_org_admin)
 
         data = {'workflowlevel2_id': 1}
 
         request = self.factory.post('/workflowlevel2sort/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'update'})
         response = view(request, pk=288)
         self.assertEqual(response.status_code, 404)
 
     def test_update_workflowlevel2sort_superuser(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         request = self.factory.post('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1()
@@ -196,7 +196,7 @@ class WorkflowLevel2SortUpdateViewsTest(TestCase):
                 'workflowlevel1': wflvl1.pk}
 
         request = self.factory.post('/workflowlevel2sort/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'update'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEqual(response.status_code, 200)
@@ -209,7 +209,7 @@ class WorkflowLevel2SortUpdateViewsTest(TestCase):
     def test_update_workflowlevel2sort_normal_user(self):
         request = self.factory.post('/workflowlevel2sort/')
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
         workflowlevel2sort = factories.WorkflowLevel2Sort(
             workflowlevel1=wflvl1)
 
@@ -217,7 +217,7 @@ class WorkflowLevel2SortUpdateViewsTest(TestCase):
                 'workflowlevel1': wflvl1.pk}
 
         request = self.factory.post('/workflowlevel2sort/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'update'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEqual(response.status_code, 200)
@@ -238,7 +238,7 @@ class WorkflowLevel2SortUpdateViewsTest(TestCase):
                 'workflowlevel1': wflvl1.pk}
 
         request = self.factory.post('/workflowlevel2sort/', data)
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'post': 'update'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEqual(response.status_code, 403)
@@ -247,17 +247,17 @@ class WorkflowLevel2SortUpdateViewsTest(TestCase):
 class WorkflowLevel2SortDeleteViewsTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.tola_user = factories.CoreUser()
+        self.core_user = factories.CoreUser()
         factories.Group()
 
     def test_delete_workflowlevel2sort_superuser(self):
-        self.tola_user.user.is_staff = True
-        self.tola_user.user.is_superuser = True
-        self.tola_user.user.save()
+        self.core_user.user.is_staff = True
+        self.core_user.user.is_superuser = True
+        self.core_user.user.save()
 
         workflowlevel2sort = factories.WorkflowLevel2Sort()
         request = self.factory.delete('/workflowlevel2sort/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEquals(response.status_code, 204)
@@ -267,12 +267,12 @@ class WorkflowLevel2SortDeleteViewsTest(TestCase):
 
     def test_delete_workflowlevel2sort_normal_user(self):
         wflvl1 = factories.WorkflowLevel1(
-            organization=self.tola_user.organization)
+            organization=self.core_user.organization)
         workflowlevel2sort = factories.WorkflowLevel2Sort(
             workflowlevel1=wflvl1)
 
         request = self.factory.delete('/workflowlevel2sort/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEquals(response.status_code, 204)
@@ -282,7 +282,7 @@ class WorkflowLevel2SortDeleteViewsTest(TestCase):
 
     def test_delete_workflowlevel2sort_diff_org_normal_user(self):
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        self.tola_user.user.groups.add(group_org_admin)
+        self.core_user.user.groups.add(group_org_admin)
 
         another_org = factories.Organization(name='Another Org')
         wflvl1 = factories.WorkflowLevel1(organization=another_org)
@@ -290,7 +290,7 @@ class WorkflowLevel2SortDeleteViewsTest(TestCase):
             workflowlevel1=wflvl1)
 
         request = self.factory.delete('/workflowlevel2sort/')
-        request.user = self.tola_user.user
+        request.user = self.core_user.user
         view = WorkflowLevel2SortViewSet.as_view({'delete': 'destroy'})
         response = view(request, pk=workflowlevel2sort.pk)
         self.assertEquals(response.status_code, 403)


### PR DESCRIPTION
## Purpose
Fix and refactor broken tests

## Approach
* tola_user -> core_user in all test files
* Portfolio factory
* Change relations to use primary key instead of URL in tests.