### PR TITLE
Ignore case sensitivity in aggregate query argument

### DIFF
--- a/gateway/tests/test_data_mesh.py
+++ b/gateway/tests/test_data_mesh.py
@@ -396,7 +396,7 @@ class DataMeshTest(TestCase):
 
         # make api request
         path = '/{}/{}/'.format(self.lm.name, 'products')
-        response = self.client.get(path, {'aggregate': 'true'})
+        response = self.client.get(path, {'aggregate': 'TRUE'})
 
         # validate result
         expected_data = {

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -117,7 +117,7 @@ class APIGatewayView(views.APIView):
         )
 
         # aggregate data if requested
-        if request.query_params.get('aggregate', None) == 'true':
+        if request.query_params.get('aggregate', '_none').lower() == 'true':
             try:
                 self._aggregate_response_data(
                     request=request,


### PR DESCRIPTION
I think it improves the usability of our data mesh.