### PR TITLE
Handle empty relationship when trying to aggregate - PLAT-278

### DIFF
--- a/gateway/views.py
+++ b/gateway/views.py
@@ -260,6 +260,10 @@ class APIGatewayView(views.APIView):
         :return list: list of dicts with relationships info
         """
         extension_map = []
+        if not logic_module.relationships:
+            logger.warning(f'Tried to aggregate but no relationship defined '
+                           f'in {logic_module}.')
+            return extension_map
         for k, v in logic_module.relationships[model_name].items():
             value = v.split('.')
             collection_args = {

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -19,12 +19,18 @@ class DisableCsrfCheck(MiddlewareMixin):
             setattr(req, attr, True)
 
 
+MIDDLEWARE_EXCEPTIONS = (
+    PermissionDenied,
+    EndpointNotFound,
+    SocialAuthFailed,
+)
+
+
 class ExceptionMiddleware(MiddlewareMixin):
 
     @staticmethod
     def process_exception(request, exception):
-        if isinstance(exception, (SocialAuthFailed, PermissionDenied,
-                                  EndpointNotFound)):
+        if isinstance(exception, MIDDLEWARE_EXCEPTIONS):
             return JsonResponse(data=json.loads(exception.content),
                                 status=exception.status)
         return None


### PR DESCRIPTION
If the user tries to aggregate data on a logic module which has no relationship defined, the Bifrost API currently returns a not so fast to understand TypeError - Traceback.

With this PR it returns now a 200 response and writes the error to the logs.

Related Ticket: https://humanitec.atlassian.net/browse/PLAT-278