### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Purpose
+_Describe the problem or feature_
+
+## Approach
+_How does this change address the problem?_
+
+### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+### Further Info
+_@mentions of the person or team responsible for reviewing proposed changes._


### PR DESCRIPTION
## Purpose
To make the PR clearer we need a template where developers will describe what's the reason for that PR and how they approached the issue that is solved in the PR.