### PR TITLE
add invitation links to the response

### DIFF
--- a/workflow/tests/test_registration.py
+++ b/workflow/tests/test_registration.py
@@ -217,6 +217,7 @@ def test_invitation(request_factory, org_admin):
     request.user = org_admin.user
     response = CoreUserViewSet.as_view({'post': 'invite'})(request)
     assert response.status_code == 200
+    assert len(response.data['invitations']) == 1
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Purpose
We don't have email server configuration for development, but for frontend testing we need to get invitation links generated at the backend (they are sent by email).

## Approach
Return invitation links with the response.
