### PR TITLE
add endpoint for reset password request validation

### DIFF
--- a/workflow/email_utils.py
+++ b/workflow/email_utils.py
@@ -12,12 +12,13 @@ def send_email(email_address: str, subject: str, context: dict, template_name: s
 
 def send_email_body(email_address: str, subject: str, text_content: str, html_content: str = None) -> int:
     msg = EmailMultiAlternatives(
+        from_email=settings.DEFAULT_FROM_EMAIL,
         subject=subject,
         body=text_content,
         to=[email_address],
     )
     if settings.DEFAULT_REPLYTO_EMAIL:
-        msg.reply_to = settings.DEFAULT_REPLYTO_EMAIL
+        msg.reply_to = [settings.DEFAULT_REPLYTO_EMAIL]
     if html_content:
         msg.attach_alternative(html_content, "text/html")
     return msg.send()

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -138,8 +138,7 @@ class CoreUserInvitationSerializer(serializers.Serializer):
 
 
 class CoreUserResetPasswordSerializer(serializers.Serializer):
-    """
-    Serializer for reset password request data
+    """Serializer for reset password request data
     """
     email = serializers.EmailField()
 
@@ -178,12 +177,9 @@ class CoreUserResetPasswordSerializer(serializers.Serializer):
         return count
 
 
-class CoreUserResetPasswordConfirmSerializer(serializers.Serializer):
+class CoreUserResetPasswordCheckSerializer(serializers.Serializer):
+    """Serializer for checking token for resetting password
     """
-    Serializer for reset password data
-    """
-    new_password1 = serializers.CharField(max_length=128)
-    new_password2 = serializers.CharField(max_length=128)
     uid = serializers.CharField()
     token = serializers.CharField()
 
@@ -195,15 +191,29 @@ class CoreUserResetPasswordConfirmSerializer(serializers.Serializer):
         except (TypeError, ValueError, OverflowError, User.DoesNotExist):
             raise serializers.ValidationError({'uid': ['Invalid value']})
 
+        # Check the token
+        if not default_token_generator.check_token(self.user, attrs['token']):
+            raise serializers.ValidationError({'token': ['Invalid value']})
+
+        return attrs
+
+
+class CoreUserResetPasswordConfirmSerializer(CoreUserResetPasswordCheckSerializer):
+    """Serializer for reset password data
+    """
+    new_password1 = serializers.CharField(max_length=128)
+    new_password2 = serializers.CharField(max_length=128)
+
+    def validate(self, attrs):
+
+        attrs = super().validate(attrs)
+
         password1 = attrs.get('new_password1')
         password2 = attrs.get('new_password2')
         if password1 and password2:
             if password1 != password2:
                 raise serializers.ValidationError("The two password fields didn't match.")
         password_validation.validate_password(password2, self.user)
-
-        if not default_token_generator.check_token(self.user, attrs['token']):
-            raise serializers.ValidationError({'token': ['Invalid value']})
 
         return attrs
 

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -201,8 +201,8 @@ class CoreUserResetPasswordCheckSerializer(serializers.Serializer):
 class CoreUserResetPasswordConfirmSerializer(CoreUserResetPasswordCheckSerializer):
     """Serializer for reset password data
     """
-    new_password1 = serializers.CharField(max_length=128)
-    new_password2 = serializers.CharField(max_length=128)
+    new_password1 = serializers.CharField(max_length=128, required=True)
+    new_password2 = serializers.CharField(max_length=128, required=True)
 
     def validate(self, attrs):
 
@@ -210,9 +210,8 @@ class CoreUserResetPasswordConfirmSerializer(CoreUserResetPasswordCheckSerialize
 
         password1 = attrs.get('new_password1')
         password2 = attrs.get('new_password2')
-        if password1 and password2:
-            if password1 != password2:
-                raise serializers.ValidationError("The two password fields didn't match.")
+        if password1 != password2:
+            raise serializers.ValidationError("The two password fields didn't match.")
         password_validation.validate_password(password2, self.user)
 
         return attrs

--- a/workflow/tests/test_coreuser.py
+++ b/workflow/tests/test_coreuser.py
@@ -264,6 +264,28 @@ class TestResetPassword(object):
         assert response.status_code == 200
         assert response.data['count'] == 0
 
+    def test_reset_password_check(self, request_factory, reset_password_request):
+        user, uid, token = reset_password_request
+        data = {
+            'uid': uid,
+            'token': token,
+        }
+        request = request_factory.post(reverse('coreuser-reset-password-check'), data)
+        response = CoreUserViewSet.as_view({'post': 'reset_password_check'})(request)
+        assert response.status_code == 200
+
+    def test_reset_password_check_expired(self, request_factory, reset_password_request):
+        user, uid, token = reset_password_request
+        data = {
+            'uid': uid,
+            'token': token,
+        }
+        mock_date = date.today() + timedelta(int(settings.PASSWORD_RESET_TIMEOUT_DAYS) + 1)
+        with mock.patch('django.contrib.auth.tokens.PasswordResetTokenGenerator._today', return_value=mock_date):
+            request = request_factory.post(reverse('coreuser-reset-password-check'), data)
+            response = CoreUserViewSet.as_view({'post': 'reset_password_check'})(request)
+            assert response.status_code == 400
+
     def test_reset_password_confirm(self, request_factory, reset_password_request):
         test_password = '5UU74e7nfU'
         user, uid, token = reset_password_request

--- a/workflow/views.py
+++ b/workflow/views.py
@@ -1,3 +1,6 @@
+"""
+ TODO: We need to break this module into multiple modules in views package, it's already to large
+"""
 import logging
 from urllib.parse import urljoin
 
@@ -12,7 +15,6 @@ import django_filters
 from rest_framework import mixins, permissions, status, viewsets, filters
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.exceptions import PermissionDenied
 import jwt
@@ -460,8 +462,11 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         except Resolver404:
             pass
         else:
-            # different permissions when creating a new user
-            if self.request.method == 'POST' and url_name == 'coreuser-create':
+            # different permissions when creating a new user or resetting password
+            if self.request.method == 'POST' and url_name in ['coreuser-create',
+                                                              'coreuser-reset-password',
+                                                              'coreuser-reset-password-check',
+                                                              'coreuser-reset-password-confirm']:
                 return [permissions.AllowAny()]
 
             # different permissions for checking token


### PR DESCRIPTION
## Purpose
- After discussion with front-end developers we decided to add additional endpoint for token validation, which will be requested before change password form appears.
- Allow reset password for anonymous users

## Approach
- reset_password_check endpoint was added
- a little refactoring of CoreUser.get_serializer() method
- replyto attribute was fixed in email sending
- permissions were updated for allowing everyone to reset password

