### PR TITLE
PLAT-328: change password reset token validation response

### DIFF
--- a/workflow/swagger.py
+++ b/workflow/swagger.py
@@ -10,6 +10,13 @@ DETAIL_RESPONSE = {200: Schema(
     })
 }
 
+SUCCESS_RESPONSE = {200: Schema(
+    type='object',
+    properties={
+        'success': Schema(type='boolean')
+    })
+}
+
 COREUSER_INVITE_RESPONSE = {200: Schema(
     type='object',
     properties={

--- a/workflow/tests/test_coreuser.py
+++ b/workflow/tests/test_coreuser.py
@@ -273,6 +273,7 @@ class TestResetPassword(object):
         request = request_factory.post(reverse('coreuser-reset-password-check'), data)
         response = CoreUserViewSet.as_view({'post': 'reset_password_check'})(request)
         assert response.status_code == 200
+        assert response.data['success'] is True
 
     def test_reset_password_check_expired(self, request_factory, reset_password_request):
         user, uid, token = reset_password_request
@@ -284,7 +285,8 @@ class TestResetPassword(object):
         with mock.patch('django.contrib.auth.tokens.PasswordResetTokenGenerator._today', return_value=mock_date):
             request = request_factory.post(reverse('coreuser-reset-password-check'), data)
             response = CoreUserViewSet.as_view({'post': 'reset_password_check'})(request)
-            assert response.status_code == 400
+            assert response.status_code == 200
+            assert response.data['success'] is False
 
     def test_reset_password_confirm(self, request_factory, reset_password_request):
         test_password = '5UU74e7nfU'

--- a/workflow/views.py
+++ b/workflow/views.py
@@ -33,7 +33,7 @@ from .permissions import (IsOrgMember, IsSuperUserOrReadOnly,
                           PERMISSIONS_PROGRAM_ADMIN, PERMISSIONS_PROGRAM_TEAM,
                           PERMISSIONS_VIEW_ONLY)
 from .swagger import (COREUSER_INVITE_RESPONSE, COREUSER_INVITE_CHECK_RESPONSE, COREUSER_RESETPASS_RESPONSE,
-                      DETAIL_RESPONSE, TOKEN_QUERY_PARAM)
+                      DETAIL_RESPONSE, SUCCESS_RESPONSE, TOKEN_QUERY_PARAM)
 from . import serializers
 
 
@@ -431,17 +431,16 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
 
     @swagger_auto_schema(methods=['post'],
                          request_body=serializers.CoreUserResetPasswordCheckSerializer,
-                         responses=DETAIL_RESPONSE)
+                         responses=SUCCESS_RESPONSE)
     @action(methods=['POST'], detail=False)
     def reset_password_check(self, request, *args, **kwargs):
         """
         This endpoint is used to check that token is valid.
         """
         serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
         return Response(
             {
-                'detail': 'The password reset token is valid.',
+                'success': serializer.is_valid(),
             },
             status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Purpose
`/coreuser/reset_password_check/` endpoint returns validation error (400) if the token is invalid. Kupfer FE needs to return 200 status response with `{"success": false}` instead of this.

## Approach
Make 200 `{"success": false}` + update swagger schema and tests