### PR TITLE
Fix reset password emails for Kupfer

### DIFF
--- a/templates/email/coreuser/password_reset.html
+++ b/templates/email/coreuser/password_reset.html
@@ -1,6 +1,8 @@
 {% load i18n %}<!DOCTYPE html>
 <html lang="en">
 <head>
+</head>
+<body>
 {% autoescape off %}
     <p>
 {% blocktrans %}You're receiving this email because you requested a password reset for your user account.{% endblocktrans %}
@@ -10,16 +12,16 @@
 {% trans "Please go to the following page and choose a new password:" %}
     </p>
 
-    {{ password_reset_link }}
     <p>
-    {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+{{ password_reset_link }}
+    </p>
+
+    <p>
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
     </p>
 
 {% trans "Thanks for using our site!" %}
 
 {% endautoescape %}
-</head>
-<body>
-
 </body>
 </html>

--- a/templates/email/coreuser/password_reset_de.html
+++ b/templates/email/coreuser/password_reset_de.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<body>
+{% autoescape off %}
+    <p>
+Guten Tag,
+    </p>
+
+    <p>
+bitte klicken Sie auf den folgenden Link, um ihr Passwort zurückzusetzen. Bitte beachten Sie, dass der Link nur 24 Stunden gültig ist:
+    </p>
+
+    <p>
+{{ password_reset_link }}
+    </p>
+
+    <p>
+Das Passwort soll nicht zurückgesetzt werden? Dann ignorieren Sie diese Nachricht bitte. Das ursprüngliche Passwort bleibt bestehen.
+    </p>
+
+    <p>
+Beste Grüße Ihr Kupfer Team
+    </p>
+
+    <p>
+Kupfer Software GmbH Tempelhofer Ufer 1, 10961 Berlin
+    </p>
+{% endautoescape %}
+</body>
+</html>

--- a/templates/email/coreuser/password_reset_de.txt
+++ b/templates/email/coreuser/password_reset_de.txt
@@ -1,0 +1,13 @@
+{% autoescape off %}
+Guten Tag,
+
+bitte klicken Sie auf den folgenden Link, um ihr Passwort zurückzusetzen. Bitte beachten Sie, dass der Link nur 24 Stunden gültig ist:
+
+{{ password_reset_link }}
+
+Das Passwort soll nicht zurückgesetzt werden? Dann ignorieren Sie diese Nachricht bitte. Das ursprüngliche Passwort bleibt bestehen.
+
+Beste Grüße Ihr Kupfer Team
+
+Kupfer Software GmbH Tempelhofer Ufer 1, 10961 Berlin
+{% endautoescape %}

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -170,8 +170,11 @@ class CoreUserResetPasswordSerializer(serializers.Serializer):
 
             # default subject and templates
             subject = 'Reset your password'
-            template_name = 'email/coreuser/password_reset.txt'
-            html_template_name = 'email/coreuser/password_reset.html'
+            # ToDo: implement languages (default should be english, but for kupfer we need german)
+            # template_name = 'email/coreuser/password_reset.txt'
+            # html_template_name = 'email/coreuser/password_reset.html'
+            template_name = 'email/coreuser/password_reset_de.txt'
+            html_template_name = 'email/coreuser/password_reset_de.html'
             count += send_email(email, subject, context, template_name, html_template_name)
 
         return count


### PR DESCRIPTION
## Purpose
The problem is, that for every newly registered user the organization has to be set manually for sending the right E-Mail-Templates.

## Approach
It changes the default E-Mails to the Kupfer E-Mails.