### PR TITLE
Add default organization for pw-reset-email-lookup

### DIFF
--- a/bifrost-api/management/commands/loadinitialdata.py
+++ b/bifrost-api/management/commands/loadinitialdata.py
@@ -8,8 +8,9 @@ from django.db import transaction
 from oauth2_provider.models import Application
 
 import factories
-from workflow.models import (ROLE_VIEW_ONLY, ROLE_ORGANIZATION_ADMIN,
-                             ROLE_PROGRAM_ADMIN, ROLE_PROGRAM_TEAM)
+from workflow.models import (
+    ROLE_VIEW_ONLY, ROLE_ORGANIZATION_ADMIN,
+    ROLE_PROGRAM_ADMIN, ROLE_PROGRAM_TEAM, Organization)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,10 @@ class Command(BaseCommand):
             )
             self._applications.append(app)
 
+    def _create_default_organization(self):
+        if settings.DEFAULT_ORG:
+            Organization.objects.get_or_create(name=settings.DEFAULT_ORG)
+
     def _create_groups(self):
         self._groups.append(factories.Group(
             id=1,
@@ -95,5 +100,6 @@ class Command(BaseCommand):
     @transaction.atomic
     def handle(self, *args, **options):
         self._create_groups()
+        self._create_default_organization()
         self._create_oauth_application()
         self._create_user()

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -161,6 +161,9 @@ class CoreUserResetPasswordSerializer(serializers.Serializer):
             if hasattr(user, 'core_user'):
                 tpl = wfm.EmailTemplate.objects.filter(organization=user.core_user.organization,
                                                        type=wfm.TEMPLATE_RESET_PASSWORD).first()
+                if not tpl:
+                    tpl = wfm.EmailTemplate.objects.filter(organization__name=settings.DEFAULT_ORG,
+                                                           type=wfm.TEMPLATE_RESET_PASSWORD).first()
                 if tpl and tpl.template:
                     context = Context(context)
                     text_content = Template(tpl.template).render(context)


### PR DESCRIPTION
## Purpose
The problem was, that for every newly registered user the default pw-reset-email has to be set manually for sending the right E-Mail-Templates.

## Approach
By adding the default organization for the E-Mail-Lookup it is now possible, to define a default email template for all organizations, which do not have a template created yet. 