### PR TITLE
Remove fixed id assignment of initial auth.Groups

### DIFF
--- a/bifrost-api/management/commands/loadinitialdata.py
+++ b/bifrost-api/management/commands/loadinitialdata.py
@@ -67,22 +67,18 @@ class Command(BaseCommand):
 
     def _create_groups(self):
         self._groups.append(factories.Group(
-            id=1,
             name=ROLE_VIEW_ONLY,
         ))
 
         self._groups.append(factories.Group(
-            id=2,
             name=ROLE_ORGANIZATION_ADMIN,
         ))
 
         self._groups.append(factories.Group(
-            id=3,
             name=ROLE_PROGRAM_ADMIN,
         ))
 
         self._groups.append(factories.Group(
-            id=4,
             name=ROLE_PROGRAM_TEAM,
         ))
 


### PR DESCRIPTION
## Purpose
At the moment, when deploying the actual version the following error was
raised:
...
File "/code/bifrost-api/management/commands/loadinitialdata.py", line 102, in handle
    self._create_groups()
  File "/code/bifrost-api/management/commands/loadinitialdata.py", line 71, in _create_groups
    name=ROLE_VIEW_ONLY,
...
django.db.utils.IntegrityError: duplicate key value violates unique constraint "auth_group_pkey"
DETAIL:  Key (id)=(1) already exists.

## Approach
By removing the id-definition the get_or_create - dilemma, when the
groups are not existing, but the id is already assigned to another group, should be fixed.