### PR TITLE
Add JWT payload to refresh_token CU-515

### DIFF
--- a/workflow/tests/test_jwt_utils.py
+++ b/workflow/tests/test_jwt_utils.py
@@ -1,10 +1,20 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.utils import timezone
+
 import factories
+from oauth2_provider.models import get_application_model, get_access_token_model, get_refresh_token_model
 
 from ..jwt_utils import payload_enricher
 from workflow.models import ROLE_ORGANIZATION_ADMIN
+
+
+AccessToken = get_access_token_model()
+RefreshToken = get_refresh_token_model()
+Application = get_application_model()
 
 
 class JWTUtilsTest(TestCase):
@@ -12,6 +22,27 @@ class JWTUtilsTest(TestCase):
     def setUp(self) -> None:
         self.rf = RequestFactory()
         self.core_user = factories.CoreUser()
+
+        # for testing refresh token
+        application = Application(
+            name="Test JWT Application",
+            user=self.core_user,
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_PASSWORD,
+        )
+        application.save()
+        access_token = AccessToken.objects.create(
+            user=self.core_user, token="1234567890",
+            application=application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write"
+        )
+        RefreshToken.objects.create(
+            access_token=access_token,
+            user=self.core_user,
+            application=application,
+            token="007"
+        )
 
     def test_jwt_payload_enricher(self):
         request = self.rf.post('', {'username': self.core_user.username})
@@ -45,6 +76,15 @@ class JWTUtilsTest(TestCase):
         self.core_user.groups.add(group_org_admin)
 
         request = self.rf.post('', {'username': self.core_user.username})
+        payload = payload_enricher(request)
+        expected_payload = {
+            'core_user_uuid': str(self.core_user.core_user_uuid),
+            'organization_uuid': str(self.core_user.organization.organization_uuid),
+        }
+        self.assertEqual(payload, expected_payload)
+
+    def test_jwt_payload_enricher_refresh_token(self):
+        request = self.rf.post('', {'refresh_token': "007"})
         payload = payload_enricher(request)
         expected_payload = {
             'core_user_uuid': str(self.core_user.core_user_uuid),

--- a/workflow/tests/test_jwt_utils.py
+++ b/workflow/tests/test_jwt_utils.py
@@ -8,14 +8,17 @@ from workflow.models import ROLE_ORGANIZATION_ADMIN
 
 
 class JWTUtilsTest(TestCase):
+
+    def setUp(self) -> None:
+        self.rf = RequestFactory()
+        self.core_user = factories.CoreUser()
+
     def test_jwt_payload_enricher(self):
-        rf = RequestFactory()
-        core_user = factories.CoreUser()
-        request = rf.post('', {'username': core_user.username})
+        request = self.rf.post('', {'username': self.core_user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'core_user_uuid': str(core_user.core_user_uuid),
-            'organization_uuid': str(core_user.organization.organization_uuid),
+            'core_user_uuid': str(self.core_user.core_user_uuid),
+            'organization_uuid': str(self.core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)
 
@@ -26,29 +29,25 @@ class JWTUtilsTest(TestCase):
         self.assertEqual(payload, {})
 
     def test_jwt_payload_enricher_superuser(self):
-        rf = RequestFactory()
-        core_user = factories.CoreUser()
-        core_user.is_superuser = True
-        core_user.save()
+        self.core_user.is_superuser = True
+        self.core_user.save()
 
-        request = rf.post('', {'username': core_user.username})
+        request = self.rf.post('', {'username': self.core_user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'core_user_uuid': str(core_user.core_user_uuid),
-            'organization_uuid': str(core_user.organization.organization_uuid),
+            'core_user_uuid': str(self.core_user.core_user_uuid),
+            'organization_uuid': str(self.core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)
 
     def test_jwt_payload_enricher_org_admin(self):
-        rf = RequestFactory()
-        core_user = factories.CoreUser()
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
-        core_user.groups.add(group_org_admin)
+        self.core_user.groups.add(group_org_admin)
 
-        request = rf.post('', {'username': core_user.username})
+        request = self.rf.post('', {'username': self.core_user.username})
         payload = payload_enricher(request)
         expected_payload = {
-            'core_user_uuid': str(core_user.core_user_uuid),
-            'organization_uuid': str(core_user.organization.organization_uuid),
+            'core_user_uuid': str(self.core_user.core_user_uuid),
+            'organization_uuid': str(self.core_user.organization.organization_uuid),
         }
         self.assertEqual(payload, expected_payload)


### PR DESCRIPTION
In order to have the refresh_token correctly working the
payload_enricher had to be extended.

### Further Info
_https://humanitec.atlassian.net/browse/CU-515_
