### PR TITLE
Add username to refresh token payload CU-515

### DIFF
--- a/workflow/jwt_utils.py
+++ b/workflow/jwt_utils.py
@@ -31,6 +31,7 @@ def payload_enricher(request):
             return {
                 'core_user_uuid': user.core_user_uuid,
                 'organization_uuid': user.organization.organization_uuid,
+                'username': user.username,
             }
         except RefreshToken.DoesNotExist:
             logger.warning('RefreshToken not found.')

--- a/workflow/tests/test_jwt_utils.py
+++ b/workflow/tests/test_jwt_utils.py
@@ -89,5 +89,6 @@ class JWTUtilsTest(TestCase):
         expected_payload = {
             'core_user_uuid': str(self.core_user.core_user_uuid),
             'organization_uuid': str(self.core_user.organization.organization_uuid),
+            'username': self.core_user.username,
         }
         self.assertEqual(payload, expected_payload)


### PR DESCRIPTION
## Purpose
The username is necessary to have a working JWT payload.

## Approach
Extend `payload_enricher`.

### Further Info
_https://humanitec.atlassian.net/browse/CU-515_
