### PR TITLE
PLAT-429: query LogicModule SQL once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .idea
 *.log
+*/settings/local.py

--- a/gateway/tests/test_data_mesh.py
+++ b/gateway/tests/test_data_mesh.py
@@ -365,8 +365,7 @@ class DataMeshTest(TestCase):
 
     @patch('gateway.views.APIGatewayView._load_swagger_resource')
     @patch('gateway.views.APIGatewayView._perform_service_request')
-    def test_expand_data_from_external_service(self, mock_perform_request,
-                                               mock_app):
+    def test_expand_data_from_external_service(self, mock_perform_request, mock_app):
         # update relationships
         self.lm.relationships['products'] = {
             'contact_uuid': 'crm.Contact'
@@ -521,12 +520,10 @@ class DataMeshTest(TestCase):
         assert json.loads(response.content) == expected_data
 
     @patch('pyswagger.App.load')
-    @patch('gateway.utils')
     @patch('gateway.views.APIGatewayView._perform_service_request')
-    def test_load_swagger_resource_of_external_service(
-            self, mock_perform_request, mock_utils, mock_app):
+    def test_load_swagger_resource_of_external_service(self, mock_perform_request, mock_app):
         # create extra service
-        crm_lm = factories.LogicModule(
+        factories.LogicModule(
             name='Contacts and Appointments Service',
             endpoint='http://crm.example.com',
             endpoint_name='crm',
@@ -539,15 +536,6 @@ class DataMeshTest(TestCase):
         }
         self.lm.save()
 
-        # mock schema urls and app
-        product_schema_url = {
-            self.lm.endpoint_name: self.lm.endpoint
-        }
-        crm_schema_url = {
-            'crm': crm_lm.endpoint
-        }
-        mock_utils.get_swagger_urls.side_effect = [product_schema_url,
-                                                   crm_schema_url]
         mock_app.return_value = Mock(App)
 
         # mock service response
@@ -585,8 +573,7 @@ class DataMeshTest(TestCase):
     @patch('pyswagger.App.load')
     @patch('gateway.utils')
     @patch('gateway.views.APIGatewayView._perform_service_request')
-    def test_load_swagger_resource_aggregate_raises_exception(
-            self, mock_perform_request, mock_utils, mock_app):
+    def test_load_swagger_resource_aggregate_raises_exception(self, mock_perform_request, mock_utils, mock_app):
         # mock schema urls and app
         product_schema_url = {
             self.lm.endpoint_name: self.lm.endpoint

--- a/gateway/tests/test_utils.py
+++ b/gateway/tests/test_utils.py
@@ -14,7 +14,7 @@ from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 
 import factories
 from gateway.exceptions import GatewayError
-from gateway.utils import GatewayJSONEncoder, validate_object_access
+from gateway.utils import GatewayJSONEncoder, validate_object_access, get_swagger_url_by_logic_module, get_swagger_urls
 from gateway.views import APIGatewayView
 
 
@@ -113,3 +113,19 @@ def test_json_dump_exception():
         json.dumps(test_obj, cls=GatewayJSONEncoder)
 
     assert error_message in str(exc.value)
+
+
+@pytest.mark.django_db()
+class TestGettingSwaggerURLs:
+
+    def test_get_swagger_url_by_logic_module(self):
+        module = factories.LogicModule.create()
+        url = get_swagger_url_by_logic_module(module)
+        assert url.startswith(module.endpoint)
+
+    def test_get_swagger_urls(self):
+        modules = factories.LogicModule.create_batch(3)
+        urls = get_swagger_urls()
+        for module in modules:
+            assert module.endpoint_name in urls
+            assert urls[module.endpoint_name] == get_swagger_url_by_logic_module(module)

--- a/gateway/utils.py
+++ b/gateway/utils.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from uuid import UUID
 
 import datetime
@@ -28,31 +29,33 @@ MODEL_VIEWSETS_DICT = {
 }
 
 
-def get_swagger_urls(service: str = None) -> dict:
+def get_swagger_url_by_logic_module(module: LogicModule) -> str:
+    """
+    Construct the endpoint URL of the service
+
+    :param LogicModule module: the logic module (service)
+    :return: OpenAPI schema URL for the logic module
+    """
+    return '{}/{}/{}.{}'.format(
+        module.endpoint, SWAGGER_LOOKUP_PATH,
+        SWAGGER_LOOKUP_FIELD, SWAGGER_LOOKUP_FORMAT
+    )
+
+
+def get_swagger_urls() -> Dict[str, str]:
     """
     Get the endpoint of the service in the database and append
     with the OpenAPI path
 
-    :param str service: the name of the service
     :return: dict
              Key-value pair with service name and OpenAPI schema URL of it
     """
-    if service is None:
-        modules = LogicModule.objects.values('endpoint', 'endpoint_name').all()
-    else:
-        modules = LogicModule.objects.values('endpoint', 'endpoint_name').filter(endpoint_name=service)
-
-    if len(modules) == 0 and service is not None:
-        msg = 'Service "{}" not found.'.format(service)
-        raise exceptions.ServiceDoesNotExist(msg, 404)
+    modules = LogicModule.objects.all()
 
     module_urls = dict()
     for module in modules:
-        swagger_url = '{}/{}/{}.{}'.format(
-            module['endpoint'], SWAGGER_LOOKUP_PATH,
-            SWAGGER_LOOKUP_FIELD, SWAGGER_LOOKUP_FORMAT
-        )
-        module_urls[module['endpoint_name']] = swagger_url
+        swagger_url = get_swagger_url_by_logic_module(module)
+        module_urls[module.endpoint_name] = swagger_url
 
     return module_urls
 


### PR DESCRIPTION
## Purpose
During one request to gateway the same SQL-queries were executed multiple type. Each query should be executed only once.

## Approach
Store logic modules as a dict in `_logic_modules` attribute of gateway view. Use this as a cache during single gateway request.