### PR TITLE
Add core_groups to filter_horizontal

### DIFF
--- a/workflow/admin.py
+++ b/workflow/admin.py
@@ -44,6 +44,7 @@ class CoreUserAdmin(UserAdmin):
         (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser', 'core_groups', 'user_permissions')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined', 'create_date', 'edit_date')}),
     )
+    filter_horizontal = ('core_groups', 'user_permissions', )
 
     def get_fieldsets(self, request, obj=None):
 


### PR DESCRIPTION
## Purpose
For easier adding the Organization UserGroups to the User.

## Approach
Extend `CoreUserAdmin`s `filter_horizontal`.