### PR TITLE
Add pagination to WFL2 by default - CU-605

### DIFF
--- a/bifrost-api/settings/base.py
+++ b/bifrost-api/settings/base.py
@@ -198,6 +198,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'workflow.permissions.IsSuperUserBrowseableAPI',
     )
+    # ToDo: Think about `DEFAULT_PAGINATION_CLASS as env variable and
+    #       customizable values with reasonable defaults
 }
 
 # Front-end application URL

--- a/workflow/pagination.py
+++ b/workflow/pagination.py
@@ -14,10 +14,6 @@ class SmallResultsSetPagination(PageNumberPagination):
 
 
 class DefaultCursorPagination(CursorPagination):
-    """
-    TODO move this to settings to provide better standardization
-    See http://www.django-rest-framework.org/api-guide/pagination/
-    """
     page_size = 30
     max_page_size = 100
     page_size_query_param = 'page_size'

--- a/workflow/pagination.py
+++ b/workflow/pagination.py
@@ -1,4 +1,4 @@
-from rest_framework.pagination import CursorPagination, PageNumberPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination, LimitOffsetPagination
 
 
 class StandardResultsSetPagination(PageNumberPagination):
@@ -21,3 +21,8 @@ class DefaultCursorPagination(CursorPagination):
     page_size = 30
     max_page_size = 100
     page_size_query_param = 'page_size'
+
+
+class DefaultLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 50
+    max_limit = 500

--- a/workflow/views/workflowlevel2.py
+++ b/workflow/views/workflowlevel2.py
@@ -1,7 +1,6 @@
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets, filters
-from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 import django_filters
 
@@ -43,15 +42,15 @@ class WorkflowLevel2ViewSet(viewsets.ModelViewSet):
             organization_id = request.user.organization_id
             queryset = queryset.filter(workflowlevel1__organization_id=organization_id)
 
-        paginate = request.GET.get('paginate')
-        if paginate and (paginate.lower() == 'true' or paginate == '1'):
+        all_results = request.GET.get('all')
+        if all_results and (all_results.lower() == 'true' or all_results == '1'):
+            serializer = self.get_serializer(queryset, many=True)
+            return Response(serializer.data)
+        else:
             page = self.paginate_queryset(queryset)
             if page is not None:
                 serializer = self.get_serializer(page, many=True)
                 return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/workflow/views/workflowlevel2.py
+++ b/workflow/views/workflowlevel2.py
@@ -1,6 +1,7 @@
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets, filters
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 import django_filters
 
@@ -8,7 +9,7 @@ from workflow.filters import WorkflowLevel2Filter
 from workflow.models import WorkflowLevel2, WorkflowLevel2Sort, WorkflowTeam, ROLE_ORGANIZATION_ADMIN
 from workflow.serializers import WorkflowLevel2Serializer, WorkflowLevel2SortSerializer
 from workflow.permissions import IsOrgMember, CoreGroupsPermissions
-from workflow.pagination import DefaultCursorPagination
+from workflow.pagination import DefaultLimitOffsetPagination
 
 
 class WorkflowLevel2ViewSet(viewsets.ModelViewSet):
@@ -70,7 +71,7 @@ class WorkflowLevel2ViewSet(viewsets.ModelViewSet):
     queryset = WorkflowLevel2.objects.all()
     permission_classes = (CoreGroupsPermissions, IsOrgMember)
     serializer_class = WorkflowLevel2Serializer
-    pagination_class = DefaultCursorPagination
+    pagination_class = DefaultLimitOffsetPagination
 
 
 class WorkflowLevel2SortViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Purpose
With an increasing number of `Workflowlevel2`s, the listing gets slower. Furthermore the existing `CursorPagination` complicates endless scrolling with lazy loadings.

## Approach
Enable Pagination by default and set `DefaultLimitOffsetPagination`.

### Further Info
https://humanitec.atlassian.net/browse/CU-605
