### PR TITLE
WAL-417: notify after build in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,22 @@ pipeline:
       status:
       - success
 
+  notify-walhall:
+    image: python:3.6
+    commands:
+      - echo $DRONE_REPO
+      - echo $DRONE_TAG
+      - pip install requests
+      - cd scripts/
+      - python notify_walhall.py -r $DRONE_REPO -t $DRONE_TAG
+    secrets:
+    - REPO_SIGNER
+    when:
+      event:
+      - tag
+      status:
+      - success
+
   deploy-docs:
     image: python:3.6
     commands:
@@ -125,22 +141,6 @@ pipeline:
       - master
       status:
       - failure
-
-  notify-walhall:
-    image: python:3.6
-    commands:
-      - echo $DRONE_REPO
-      - echo $DRONE_TAG
-      - pip install requests
-      - cd scripts/
-      - python notify_walhall.py -r $DRONE_REPO -t $DRONE_TAG
-    secrets:
-    - REPO_SIGNER
-    when:
-      event:
-      - tag
-      status:
-      - success
 
 services:
   postgres:


### PR DESCRIPTION
## Purpose
Move drone notification step just after build step (deploy_doc and slack steps could be failed)
