### PR TITLE
PLAT-457: default value for DEFAULT_ORG env var

### DIFF
--- a/bifrost-api/settings/base.py
+++ b/bifrost-api/settings/base.py
@@ -329,7 +329,7 @@ RABBIT_VHOST = os.getenv('RABBIT_VHOST')
 RABBIT_WALHALL_QUEUE = os.getenv('RABBIT_WALHALL_QUEUE')
 
 
-DEFAULT_ORG = os.getenv('DEFAULT_ORG', None)
+DEFAULT_ORG = os.getenv('DEFAULT_ORG', 'My organization')
 
 if os.getenv('EMAIL_BACKEND') == 'SMTP':
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
## Purpose
Now if DEFAULT_ORG env var is not set the default organization is not created, and superuser doesn't belong to any org and doesn't have organization_id in JWT token, that leads to some problems in FE.

## Approach
To create a default organization if the env var is not set.

