### PR TITLE
Revert "PLAT-429: cache responses from duplicated logic module requests"

### DIFF
--- a/gateway/views.py
+++ b/gateway/views.py
@@ -426,16 +426,11 @@ class APIGatewayView(views.APIView):
         """
         req, resp = self._get_req_and_rep(app, request, **kwargs)
 
-        req.prepare()  # prepare request to get URL from it for checking cache (we don't care about schema for this)
-        key_url = req.url
-
-        if key_url not in self._data:
-            headers = self._get_service_request_headers(request)
-            try:
-                self._data[key_url] = client.request((req, resp), headers=headers)
-            except Exception as e:
-                error_msg = (f'An error occurred when redirecting the request to '
-                             f'or receiving the response from the service.\n'
-                             f'Origin: ({e.__class__.__name__}: {e})')
-                raise exceptions.PySwaggerError(error_msg)
-        return self._data[key_url]
+        headers = self._get_service_request_headers(request)
+        try:
+            return client.request((req, resp), headers=headers)
+        except Exception as e:
+            error_msg = (f'An error occurred when redirecting the request to '
+                         f'or receiving the response from the service.\n'
+                         f'Origin: ({e.__class__.__name__}: {e})')
+            raise exceptions.PySwaggerError(error_msg)


### PR DESCRIPTION
## Purpose
The approach on caching responses from duplicated logic module requests does not consider multipart/form-data.

```
File "/code/gateway/views.py" in post
  83.         return self.make_service_request(request, *args, **kwargs)

File "/code/gateway/views.py" in make_service_request
  121.             **kwargs

File "/code/gateway/views.py" in _perform_service_request
  429.         req.prepare()  # prepare request to get URL from it for checking cache (we don't care about schema for this)

File "/usr/local/lib/python3.6/site-packages/pyswagger/io.py" in prepare
  212.                 content_type, self.__data = self._prepare_files(encoding)

File "/usr/local/lib/python3.6/site-packages/pyswagger/io.py" in _prepare_files
  92.             raise errs.SchemaError('content type {0} does not present in {1}'.format(content_type, self.__op.consumes))

Exception Type: SchemaError at /documents/documents/
Exception Value: content type multipart/form-data does not present in ['application/json']
```

## Approach
Revert this optimization.
*This reverts commit f94186e9874c73d26acb52ae16ef3b59096deb26.*

### Further Info
_PLAT-429_
