### PR TITLE
PLAT-429: fixing retrieving URL for caching for multipart response

### DIFF
--- a/gateway/views.py
+++ b/gateway/views.py
@@ -426,11 +426,16 @@ class APIGatewayView(views.APIView):
         """
         req, resp = self._get_req_and_rep(app, request, **kwargs)
 
-        headers = self._get_service_request_headers(request)
-        try:
-            return client.request((req, resp), headers=headers)
-        except Exception as e:
-            error_msg = (f'An error occurred when redirecting the request to '
-                         f'or receiving the response from the service.\n'
-                         f'Origin: ({e.__class__.__name__}: {e})')
-            raise exceptions.PySwaggerError(error_msg)
+        req.prepare(handle_files=False)  # prepare request to get URL from it for checking cache
+        key_url = req.url
+
+        if key_url not in self._data:
+            headers = self._get_service_request_headers(request)
+            try:
+                self._data[key_url] = client.request((req, resp), headers=headers)
+            except Exception as e:
+                error_msg = (f'An error occurred when redirecting the request to '
+                             f'or receiving the response from the service.\n'
+                             f'Origin: ({e.__class__.__name__}: {e})')
+                raise exceptions.PySwaggerError(error_msg)
+        return self._data[key_url]


### PR DESCRIPTION
## Purpose
Instead of reverting the request-cache-optimization this Patch might fix it.
Related PR: #117

## Approach
prepare() with handle_files=False (tested in Postman)

### Further Info
@ralfzen 
