### PR TITLE
Add UUIDPrimaryKeyRelatedField to CoreGroupSerializer

### DIFF
--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -4,6 +4,7 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import Client, RequestFactory, TestCase
+from oauth2_provider.views.mixins import OAuthLibMixin
 
 from rest_framework.reverse import reverse
 
@@ -50,6 +51,17 @@ class HealthCheckViewTest(TestCase):
         c = Client()
         response = c.get('/health_check/')
         self.assertEqual(response.status_code, 200)
+
+
+class TestOAuthUserEndpoint(object):
+
+    @pytest.mark.django_db()
+    def test_get_oauth_user(self, request_factory, core_user, monkeypatch):
+        request = request_factory.get('oauthuser')
+        request.user = core_user
+        monkeypatch.setattr(OAuthLibMixin, 'verify_request', lambda x, y: [True, request])
+        response = views.OAuthUserEndpoint.as_view()(request)
+        assert response.status_code == 200
 
 
 class TestOAuthComplete(object):

--- a/web/views.py
+++ b/web/views.py
@@ -47,7 +47,6 @@ class OAuthUserEndpoint(ProtectedResourceView):
             'core_user': CoreUserSerializer(instance=user, context={'request': request}).data,
             'organization': OrganizationSerializer(instance=user.organization, context={'request': request}).data
         }
-
         return HttpResponse(json.dumps(body))
 
 

--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -11,7 +11,7 @@ from django.template import Template, Context
 from rest_framework import serializers
 from workflow import models as wfm
 from workflow.email_utils import send_email, send_email_body
-
+from workflow.models import Organization
 
 User = get_user_model()
 
@@ -63,9 +63,18 @@ class WorkflowLevel2Serializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class UUIDPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
+
+    def to_representation(self, value):
+        return str(super().to_representation(value))
+
+
 class CoreGroupSerializer(serializers.ModelSerializer):
 
     permissions = PermissionsField(required=False)
+    organization = UUIDPrimaryKeyRelatedField(required=False,
+                                              queryset=Organization.objects.all(),
+                                              help_text="Related Org to associate with")
 
     class Meta:
         model = wfm.CoreGroup

--- a/workflow/tests/fixtures.py
+++ b/workflow/tests/fixtures.py
@@ -27,6 +27,11 @@ def org_member(org):
 
 
 @pytest.fixture
+def core_group(org):
+    return factories.CoreGroup(organization=org)
+
+
+@pytest.fixture
 def org_admin(org):
     group_org_admin, _ = wfm.CoreGroup.objects.get_or_create(organization=org, is_org_level=True,
                                                              permissions=wfm.PERMISSIONS_ORG_ADMIN,

--- a/workflow/tests/test_serializers.py
+++ b/workflow/tests/test_serializers.py
@@ -1,0 +1,70 @@
+import pytest
+
+from workflow.serializers import OrganizationSerializer, CoreGroupSerializer, CoreUserSerializer
+from .fixtures import org, core_group, org_member
+
+
+@pytest.mark.django_db()
+def test_org_serializer(request_factory, org):
+    request = request_factory.get('')
+    serializer = OrganizationSerializer(org, context={'request': request})
+    data = serializer.data
+    keys = ['organization_uuid',
+            'name',
+            'description',
+            'organization_url',
+            'level_1_label',
+            'level_2_label',
+            'level_3_label',
+            'level_4_label',
+            'create_date',
+            'edit_date',
+            'subscription_id',
+            'used_seats',
+            'oauth_domains',
+            'date_format',
+            'phone',
+            'industries',
+            ]
+    assert set(data.keys()) == set(keys)
+
+
+@pytest.mark.django_db()
+def test_core_groups_serializer(request_factory, core_group):
+    request = request_factory.get('')
+    serializer = CoreGroupSerializer(core_group, context={'request': request})
+    data = serializer.data
+    keys = ['id',
+            'uuid',
+            'name',
+            'is_global',
+            'is_org_level',
+            'permissions',
+            'organization',
+            'workflowlevel1s',
+            'workflowlevel2s',
+            ]
+    assert set(data.keys()) == set(keys)
+    assert isinstance(data['organization'], str)
+
+
+@pytest.mark.django_db()
+def test_core_user_serializer(request_factory, org_member):
+    request = request_factory.get('')
+    serializer = CoreUserSerializer(org_member, context={'request': request})
+    data = serializer.data
+    keys = ['id',
+            'core_user_uuid',
+            'first_name',
+            'last_name',
+            'email',
+            'username',
+            'is_active',
+            'title',
+            'contact_info',
+            'privacy_disclaimer_accepted',
+            'organization',
+            'core_groups',
+            ]
+    assert set(data.keys()) == set(keys)
+    assert isinstance(data['organization'], dict)


### PR DESCRIPTION
## Purpose
The CoreGroupSerializer was returning real UUIDs for the organization, because it has now a `UUIDField` as a *primary key*.

## Approach
Add a custom `PrimaryKeyRelatedField`-SerializerField and overwrite the `to_representation`.