### PR TITLE
Data mesh joinrecord endpoints PLAT-464

### DIFF
--- a/datamesh/serializers.py
+++ b/datamesh/serializers.py
@@ -1,0 +1,70 @@
+from collections import OrderedDict
+
+from rest_framework import serializers
+
+from datamesh.models import JoinRecord, Relationship, LogicModuleModel
+
+
+class JoinRecordSerializer(serializers.ModelSerializer):
+    """
+    The model_choices are created based on the logic_module__name as a prefix and the model name.
+    Example: locationSiteProfile
+    """
+
+    _model_choices = list()
+    _model_choices_map = dict()
+
+    origin_model_name = serializers.ChoiceField(choices=_model_choices, write_only=True)
+    related_model_name = serializers.ChoiceField(choices=_model_choices, write_only=True)
+
+    def __init__(self, *args, **kwargs):
+        for model in LogicModuleModel.objects.select_related(
+                'logic_module__name').all().values('logic_module__name', 'model', 'pk'):
+            choice = model['logic_module__name'] + model['model']
+            self._model_choices.append(choice)
+            self._model_choices_map.update({choice: model['pk']})
+        super().__init__(*args, **kwargs)
+
+    def create(self, validated_data: dict) -> JoinRecord:
+        """Get logic_module_models, get_or_create `Relationship`s and save in case it is not already existing."""
+        origin_model_pk = self._model_choices_map[validated_data.pop('origin_model_name')]
+        related_model_pk = self._model_choices_map[validated_data.pop('related_model_name')]
+        relationship, _ = Relationship.objects.get_or_create(
+            origin_model_id=origin_model_pk,
+            related_model_id=related_model_pk
+        )
+        organization_uuid = self.context['request'].session.get('jwt_organization_uuid', None)
+        join_record, _ = JoinRecord.objects.get_or_create(
+            relationship=relationship,
+            organization_id=organization_uuid,
+            **validated_data
+        )
+        return join_record
+
+    def update(self, instance: JoinRecord, validated_data: dict) -> dict:
+        origin_model_pk = self._model_choices_map[validated_data.pop('origin_model_name')]
+        related_model_pk = self._model_choices_map[validated_data.pop('related_model_name')]
+        relationship, _ = Relationship.objects.get_or_create(
+            origin_model_id=origin_model_pk,
+            related_model_id=related_model_pk
+        )
+        instance.relationship = relationship
+        for key, value in validated_data.items():
+            setattr(instance, key, value)
+        instance.save()
+        return instance
+
+    def to_representation(self, instance: JoinRecord) -> OrderedDict:
+        """Add origin_model_name and related_model_name."""
+        ret_repr = super().to_representation(instance)
+        ret_repr.update(
+            {'origin_model_name': f'{instance.relationship.origin_model.logic_module.name}'
+                f'{instance.relationship.origin_model.model}',
+             'related_model_name': f'{instance.relationship.related_model.logic_module.name}'
+                f'{instance.relationship.related_model.model}'})
+        return ret_repr
+
+    class Meta:
+        model = JoinRecord
+        exclude = ('relationship', )
+        read_only_fields = ('organization', )

--- a/datamesh/tests/test_serializers.py
+++ b/datamesh/tests/test_serializers.py
@@ -1,0 +1,27 @@
+import pytest
+
+from datamesh.serializers import JoinRecordSerializer
+from .fixtures import join_record
+
+
+@pytest.mark.django_db()
+def test_join_record_serializer_from_instance(request_factory, join_record):
+    request = request_factory.get('')
+    request.session = {
+        'jwt_organization_uuid': join_record.organization.organization_uuid,
+    }
+    serializer = JoinRecordSerializer(instance=join_record,
+                                      context={'request': request})
+    keys = [
+        "join_records_uuid",
+        "record_id",
+        "record_uuid",
+        "related_record_id",
+        "related_record_uuid",
+        "organization",
+        "origin_model_name",
+        "related_model_name",
+    ]
+    data = serializer.data
+    assert set(data.keys()) == set(keys)
+    assert data['organization'] == join_record.organization.organization_uuid

--- a/datamesh/tests/test_views.py
+++ b/datamesh/tests/test_views.py
@@ -1,0 +1,54 @@
+import pytest
+
+import factories
+from datamesh import views
+
+from workflow.tests.fixtures import org, org_admin, org_member, TEST_USER_DATA
+from .fixtures import logic_module_model
+
+
+@pytest.mark.django_db()
+class TestJoinRecordBase:
+
+    session = {
+        'jwt_organization_uuid': TEST_USER_DATA['organization_uuid'],
+    }
+
+    def set_up(self):
+        self.logic_module1 = factories.LogicModule(
+            name='document'
+        )
+        self.logic_module2 = factories.LogicModule(
+            name='crm'
+        )
+        self.logic_module_model1 = factories.LogicModuleModel(
+            logic_module=self.logic_module1,
+            model='Document'
+        )
+        self.logic_module_model2 = factories.LogicModuleModel(
+            logic_module=self.logic_module2,
+            model='Appointment'
+        )
+
+
+@pytest.mark.django_db()
+class TestJoinRecordCreateView(TestJoinRecordBase):
+
+    def test_join_record_create_view(self, request_factory, org_admin):
+
+        self.set_up()
+
+        data = {
+            "origin_model_name": "documentDocument",
+            "related_model_name": "crmAppointment",
+            "record_uuid": "322f71fe-b606-48ce-bae6-d5254479ad6f",
+            "related_record_id": 7
+        }
+        request = request_factory.post('', data, format='json')
+        request.user = org_admin
+        request.session = self.session
+        response = views.JoinRecordViewSet.as_view({'post': 'create'})(request)
+        assert response.status_code == 201
+        assert response.data['origin_model_name'] == 'documentDocument'
+        assert response.data['related_model_name'] == 'crmAppointment'
+        assert response.data['organization'] == TEST_USER_DATA['organization_uuid']

--- a/datamesh/urls.py
+++ b/datamesh/urls.py
@@ -1,0 +1,10 @@
+from rest_framework import routers
+
+from . import views
+
+
+router = routers.SimpleRouter()
+
+router.register('joinrecords', views.JoinRecordViewSet)
+
+urlpatterns = router.urls

--- a/datamesh/views.py
+++ b/datamesh/views.py
@@ -1,0 +1,15 @@
+from rest_framework import mixins
+from rest_framework.viewsets import GenericViewSet
+
+from datamesh.models import JoinRecord
+from datamesh.serializers import JoinRecordSerializer
+
+
+class JoinRecordViewSet(mixins.CreateModelMixin,
+                        mixins.RetrieveModelMixin,
+                        mixins.UpdateModelMixin,
+                        mixins.DestroyModelMixin,
+                        GenericViewSet):
+
+    queryset = JoinRecord.objects.all()
+    serializer_class = JoinRecordSerializer

--- a/factories/datamesh_models.py
+++ b/factories/datamesh_models.py
@@ -3,6 +3,7 @@ from factory import DjangoModelFactory, SubFactory, Faker
 from datamesh.models import (LogicModuleModel as LogicModulModelM,
                              Relationship as RelationshipM,
                              JoinRecord as JoinRecordM)
+from factories import Organization
 from gateway.models import LogicModule as LogicModuleM
 
 
@@ -30,6 +31,9 @@ class Relationship(DjangoModelFactory):
 
 class JoinRecord(DjangoModelFactory):
     relationship = SubFactory(Relationship)
+    organization = SubFactory(Organization)
+    record_id = 1
+    related_record_id = 2
 
     class Meta:
         model = JoinRecordM

--- a/web/urls.py
+++ b/web/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('oauthuser/', OAuthUserEndpoint.as_view()),
     path('health_check/', include('health_check.urls')),
+    path('datamesh/', include('datamesh.urls')),
     path('', include('gateway.urls')),
     path('', include('workflow.urls')),
     # Auth backend URL's

--- a/workflow/tests/fixtures.py
+++ b/workflow/tests/fixtures.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
@@ -13,12 +15,16 @@ TEST_USER_DATA = {
     'username': 'johnsnow',
     'password': '123qwe',
     'organization_name': 'Humanitec',
+    'organization_uuid': uuid.uuid4(),
 }
 
 
 @pytest.fixture
 def org():
-    return factories.Organization(name=TEST_USER_DATA['organization_name'])
+    return factories.Organization(
+        name=TEST_USER_DATA['organization_name'],
+        organization_uuid=TEST_USER_DATA['organization_uuid'],
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Purpose
With having an endpoint for the record relationships the pointer-information or relationship can be saved on the relationship-model and doesn’t have to be defined in the model itself. That means no need for workflowlevel2_uuids, appointment_uuids or siteprofile_uuids anymore. The relationships will be defined in `/datamesh/joinrecords/`.

## Approach
Create a `JoinRecordSerializer`, and endpoints to create, retrieve, update and delete.

https://humanitec.atlassian.net/browse/PLAT-464