### PR TITLE
PLAT-542: fix CoreUser & CoreGroup permissions

### DIFF
--- a/workflow/permissions.py
+++ b/workflow/permissions.py
@@ -80,7 +80,7 @@ class AllowOnlyOrgAdmin(permissions.BasePermission):
         if request.user.is_anonymous:
             return False
 
-        if request.user.is_active and request.user.is_superuser:
+        if request.user.is_active and request.user.is_global_admin:
             return True
 
         if request.user.is_org_admin:
@@ -94,7 +94,7 @@ class IsOrgMember(permissions.BasePermission):
         if request.user.is_anonymous or not request.user.is_active:
             return False
 
-        if request.user.is_active and request.user.is_superuser:
+        if request.user.is_active and request.user.is_global_admin:
             return True
 
         if view.action == 'create':
@@ -114,7 +114,7 @@ class IsOrgMember(permissions.BasePermission):
         should be allowed to act on a particular object
         """
 
-        if request.user.is_active and request.user.is_superuser:
+        if request.user.is_active and request.user.is_global_admin:
             return True
         user_org = request.user.organization_id
         try:

--- a/workflow/tests/test_coregroupview.py
+++ b/workflow/tests/test_coregroupview.py
@@ -101,7 +101,7 @@ class TestCoreGroupViewsPermissions:
 @pytest.mark.django_db()
 class TestCoreGroupCreateView:
 
-    def test_coregroup_create_fail(self, request_factory, org_admin):
+    def test_coregroup_create_fail_empty(self, request_factory, org_admin):
         request = request_factory.post(reverse('coregroup-list'), {}, format='json')
         request.user = org_admin
         response = CoreGroupViewSet.as_view({'post': 'create'})(request)
@@ -115,6 +115,7 @@ class TestCoreGroupCreateView:
         assert response.status_code == 201
         coregroup = wfm.CoreGroup.objects.get(name='New Group')
         assert coregroup.permissions == 4  # check default permissions
+        assert coregroup.organization == org_admin.organization
 
     def test_coregroup_create_fail(self, request_factory, org_admin):
         request = request_factory.post(reverse('coregroup-list'),
@@ -143,6 +144,7 @@ class TestCoreGroupCreateView:
         assert response.status_code == 201
         coregroup = wfm.CoreGroup.objects.get(name='New Group')
         assert coregroup.permissions == 9
+        assert coregroup.organization == org_admin.organization
 
     def test_coregroup_create_int(self, request_factory, org_admin):
         # int values should also work as well as boolean
@@ -156,6 +158,7 @@ class TestCoreGroupCreateView:
         assert response.status_code == 201
         coregroup = wfm.CoreGroup.objects.get(name='New Group')
         assert coregroup.permissions == 9
+        assert coregroup.organization == org_admin.organization
 
 
 @pytest.mark.django_db()

--- a/workflow/views/coregroup.py
+++ b/workflow/views/coregroup.py
@@ -23,3 +23,8 @@ class CoreGroupViewSet(viewsets.ModelViewSet):
             # TODO: Shall user also view global groups?
             queryset = queryset.filter(organization_id=request.user.organization_id)
         return Response(self.get_serializer(queryset, many=True).data)
+
+    def perform_create(self, serializer):
+        """ override this method to set organization from request """
+        organization = self.request.user.organization
+        serializer.save(organization=organization)

--- a/workflow/views/coreuser.py
+++ b/workflow/views/coreuser.py
@@ -15,7 +15,7 @@ from workflow.models import CoreUser, Organization
 from workflow.serializers import (CoreUserSerializer, CoreUserWritableSerializer, CoreUserInvitationSerializer,
                                   CoreUserResetPasswordSerializer, CoreUserResetPasswordCheckSerializer,
                                   CoreUserResetPasswordConfirmSerializer)
-from workflow.permissions import AllowAuthenticatedRead, AllowOnlyOrgAdmin
+from workflow.permissions import AllowAuthenticatedRead, AllowOnlyOrgAdmin, IsOrgMember
 from workflow.swagger import (COREUSER_INVITE_RESPONSE, COREUSER_INVITE_CHECK_RESPONSE, COREUSER_RESETPASS_RESPONSE,
                               DETAIL_RESPONSE, SUCCESS_RESPONSE, TOKEN_QUERY_PARAM)
 from workflow.jwt_utils import create_invitation_token
@@ -241,7 +241,7 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
                 return [permissions.AllowAny()]
 
             if self.action in ['update', 'partial_update', 'invite']:
-                return [AllowOnlyOrgAdmin()]
+                return [AllowOnlyOrgAdmin(), IsOrgMember()]
 
         return super(CoreUserViewSet, self).get_permissions()
 


### PR DESCRIPTION
## Purpose
1) Bug in permissions: Admin user can edit users from another organizations.
2) When creating CoreGroup, organization was not set to it, it should be taken from CoreUser who creates it.

## Approach
1) (First commit) Added `IsOrgMember` class to permissions for` CoreUser` (for editing). Also fixed UpdateCoreUser tests, they worked incorrectly.
2) When creating new CoreGroup assign organization from request user to it (and fix tests to check it). 

