### PR TITLE
Add query_params and fix POST, PUT, PATCH data

### DIFF
--- a/gateway/request.py
+++ b/gateway/request.py
@@ -46,7 +46,7 @@ class BaseGatewayRequest(object):
 
     def perform(self) -> GatewayResponse:
         """
-        Makes request to underlying service(s) and returns aggregated response
+        Make request to underlying service(s) and returns aggregated response.
         """
         # init swagger spec from the service swagger doc file
         try:
@@ -58,7 +58,7 @@ class BaseGatewayRequest(object):
 
     def _get_logic_module(self, service_name: str) -> LogicModule:
         """
-        Retrieve LogicModule by service name
+        Retrieve LogicModule by service name.
         """
         if service_name not in self._logic_modules:
             try:
@@ -69,7 +69,7 @@ class BaseGatewayRequest(object):
 
     def _get_swagger_spec(self, endpoint_name: str) -> Spec:
         """
-        Get Swagger spec of specified service
+        Get Swagger spec of specified service.
         """
         logic_module = self._get_logic_module(endpoint_name)
         schema_url = utils.get_swagger_url_by_logic_module(logic_module)
@@ -267,7 +267,9 @@ class GatewayRequest(BaseGatewayRequest):
         return
 
     def _add_nested_data(self, data_item: dict, relationships: QuerySet, origin_lookup_field: str) -> None:
-        """ Nests data retrieved from related services """
+        """
+        Nest data retrieved from related services.
+        """
         origin_pk = data_item.get(origin_lookup_field)
         if not origin_pk:
             raise exceptions.DataMeshError(


### PR DESCRIPTION
## Purpose
Two critical bugs occurred with bravados:
- The filters didn't work
- The POST, PUT, PATCH requests were not working fully

## Approach
- The `query_params` from the original request had to be added to the passed request in the method call.
- When the request is sent as `content-type=application/json` the data must be dumped as JSON and cannot be nested into another `'data'`-variable. Also, the header needs to be set with this `content-type`.
- For other content-types like `multipart/form-data` the `content-type` cannot be taken from the original request.

## Pre-Merge TODOs:
- [ ] Write Tests for different content-types
- [ ] Write Tests for data-mesh, especially not passing the query-params

### Further Info
For POST with params see: https://stackoverflow.com/questions/15900338/python-request-post-with-param-data

