### PR TITLE
CU-761 Add `id` to serializers

### DIFF
--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -50,6 +50,7 @@ class WorkflowLevel1Serializer(serializers.ModelSerializer):
 
 
 class WorkflowLevelTypeSerializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(source='uuid', read_only=True)
 
     class Meta:
         model = wfm.WorkflowLevelType
@@ -57,6 +58,7 @@ class WorkflowLevelTypeSerializer(serializers.ModelSerializer):
 
 
 class WorkflowLevel2Serializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(source='level2_uuid', read_only=True)
 
     class Meta:
         model = wfm.WorkflowLevel2
@@ -252,6 +254,7 @@ class CoreUserResetPasswordConfirmSerializer(CoreUserResetPasswordCheckSerialize
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(source='organization_uuid', read_only=True)
 
     class Meta:
         model = wfm.Organization

--- a/workflow/tests/fixtures.py
+++ b/workflow/tests/fixtures.py
@@ -60,3 +60,13 @@ def auth_api_client():
     api_client = APIClient()
     api_client.force_authenticate(user=factories.CoreUser.create())
     return api_client
+
+
+@pytest.fixture
+def wfl2():
+    return factories.WorkflowLevel2()
+
+
+@pytest.fixture
+def wfl_type():
+    return factories.WorkflowLevelType()

--- a/workflow/tests/test_serializers.py
+++ b/workflow/tests/test_serializers.py
@@ -1,7 +1,8 @@
 import pytest
 
-from workflow.serializers import OrganizationSerializer, CoreGroupSerializer, CoreUserSerializer
-from .fixtures import org, core_group, org_member
+from workflow.serializers import OrganizationSerializer, CoreGroupSerializer, CoreUserSerializer, \
+    WorkflowLevel2Serializer, WorkflowLevelTypeSerializer
+from .fixtures import org, core_group, org_member, wfl2, wfl_type
 
 
 @pytest.mark.django_db()
@@ -9,7 +10,8 @@ def test_org_serializer(request_factory, org):
     request = request_factory.get('')
     serializer = OrganizationSerializer(org, context={'request': request})
     data = serializer.data
-    keys = ['organization_uuid',
+    keys = ['id',
+            'organization_uuid',
             'name',
             'description',
             'organization_url',
@@ -68,3 +70,43 @@ def test_core_user_serializer(request_factory, org_member):
             ]
     assert set(data.keys()) == set(keys)
     assert isinstance(data['organization'], dict)
+
+
+@pytest.mark.django_db()
+def test_workflow_level2_serializer(request_factory, wfl2):
+    request = request_factory.get('')
+    serializer = WorkflowLevel2Serializer(wfl2, context={'request': request})
+    data = serializer.data
+    keys = ["id",
+            "level2_uuid",
+            "description",
+            "name",
+            "notes",
+            "parent_workflowlevel2",
+            "short_name",
+            "create_date",
+            "edit_date",
+            "start_date",
+            "end_date",
+            "workflowlevel1",
+            "created_by",
+            "type",
+            "core_groups",
+            ]
+    assert set(data.keys()) == set(keys)
+    assert data["id"] == data["level2_uuid"]
+
+
+@pytest.mark.django_db()
+def test_workflow_level_type_serializer(request_factory, wfl_type):
+    request = request_factory.get('')
+    serializer = WorkflowLevelTypeSerializer(wfl_type, context={'request': request})
+    data = serializer.data
+    keys = ["id",
+            "uuid",
+            "name",
+            "create_date",
+            "edit_date",
+            ]
+    assert set(data.keys()) == set(keys)
+    assert data["id"] == data["uuid"]

--- a/workflow/tests/test_workflowlevel2serializers.py
+++ b/workflow/tests/test_workflowlevel2serializers.py
@@ -6,37 +6,6 @@ import factories
 from ..serializers import WorkflowLevel2NameSerializer, WorkflowLevel2Serializer
 
 
-class Workflowlevel2SerializerTest(TestCase):
-    def setUp(self):
-        self.factory = APIRequestFactory()
-
-    def test_contains_expected_fields(self):
-        wfl2 = factories.WorkflowLevel2()
-
-        serializer = WorkflowLevel2Serializer(instance=wfl2)
-
-        data = serializer.data
-
-        keys = [
-            'name',
-            'level2_uuid',
-            'workflowlevel1',
-            'short_name',
-            'description',
-            'type',
-            'notes',
-            'parent_workflowlevel2',
-            'start_date',
-            'end_date',
-            'core_groups',
-            'edit_date',
-            'create_date',
-            'created_by',
-        ]
-
-        self.assertEqual(set(data.keys()), set(keys))
-
-
 class WorkflowLevel2NameSerializerTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()


### PR DESCRIPTION
## Purpose
Currently, some services have ID field and some not, we need to identify which of them don’t have it and add it to the serializer.