### PR TITLE
PLAT-526: tests for async gateway view

### DIFF
--- a/gateway/request.py
+++ b/gateway/request.py
@@ -493,8 +493,8 @@ class AsyncGatewayRequest(BaseGatewayRequest):
             async with method(url, data=self.get_request_data(), headers=self.get_headers()) as response:
                 try:
                     content = await response.json()
-                except aiohttp.ContentTypeError:
-                    content = response.content
+                except json.JSONDecodeError:
+                    content = await response.content.read()
             return_data = (content, response.status, response.headers)
 
             # Cache data if request is cache-valid

--- a/gateway/tests/test_views_async.py
+++ b/gateway/tests/test_views_async.py
@@ -1,0 +1,190 @@
+import os
+import json
+from unittest.mock import patch
+
+import pytest
+
+import factories
+from workflow.tests.fixtures import auth_api_client
+from .fixtures import logic_module, datamesh
+from .utils import AiohttpResponseMock, create_aiohttp_session_mock
+
+
+CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
+
+
+
+@pytest.mark.parametrize("content,content_type", [(b'{"details": "IT IS A TEST"}', 'application/json'),
+                                                  (b'IT IS A TEST', 'text/html; charset=utf-8')])
+@pytest.mark.django_db()
+@patch('gateway.request.aiohttp.ClientSession')
+def test_make_service_request_data_and_raw(client_session_mock, auth_api_client, logic_module, content, content_type,
+                                           event_loop):
+    url = f'/async/{logic_module.endpoint_name}/thumbnail/1/'
+
+    # mock aiohttp responses
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
+        swagger_body = r.read()
+
+    responses = [
+        AiohttpResponseMock(method='GET', url=f'{logic_module.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{logic_module.endpoint}/thumbnail/1/', status=200, body=content,
+                            headers={'Content-Type': content_type}),
+    ]
+    client_session_mock.return_value = create_aiohttp_session_mock(responses, loop=event_loop)
+
+    # make api request
+    response = auth_api_client.get(url)
+
+    assert response.status_code == 200
+    assert response.content == content
+    assert response.has_header('Content-Type')
+    assert response.get('Content-Type') == content_type
+
+
+@pytest.mark.django_db()
+@patch('gateway.request.aiohttp.ClientSession')
+def test_make_service_request_to_unexisting_list_endpoint(client_session_mock, auth_api_client, logic_module,
+                                                          event_loop):
+
+    url = f'/async/{logic_module.endpoint_name}/nowhere/'
+
+    # mock aiohttp responses
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
+        swagger_body = r.read()
+    responses = [
+        AiohttpResponseMock(method='GET', url=f'{logic_module.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_body, headers={'Content-Type': 'application/json'}),
+    ]
+    client_session_mock.return_value = create_aiohttp_session_mock(responses, loop=event_loop)
+
+    # make api request
+    response = auth_api_client.get(url)
+
+    # This operation doesn't exist in Swagger schema so 404 must be thrown
+    assert response.status_code == 404
+    assert response.has_header('Content-Type')
+    assert response.get('Content-Type') == 'application/json'
+    assert json.loads(response.content)['detail'] == "Endpoint not found: GET /nowhere/"
+
+
+@pytest.mark.django_db()
+@patch('gateway.request.aiohttp.ClientSession')
+def test_make_service_request_to_unexisting_detail_endpoint(client_session_mock, auth_api_client, logic_module,
+                                                            event_loop):
+
+    url = f'/async/{logic_module.endpoint_name}/nowhere/123/'
+
+    # mock aiohttp responses
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
+        swagger_body = r.read()
+    responses = [
+        AiohttpResponseMock(method='GET', url=f'{logic_module.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_body, headers={'Content-Type': 'application/json'}),
+    ]
+    client_session_mock.return_value = create_aiohttp_session_mock(responses, loop=event_loop)
+
+    # make api request
+    response = auth_api_client.get(url)
+
+    # This operation doesn't exist in Swagger schema so 404 must be thrown
+    assert response.status_code == 404
+    assert response.has_header('Content-Type')
+    assert response.get('Content-Type') == 'application/json'
+    assert json.loads(response.content)['detail'] == "Endpoint not found: GET /nowhere/{id}/"
+
+
+@pytest.mark.django_db()
+@patch('gateway.request.aiohttp.ClientSession')
+def test_make_service_request_with_datamesh_detailed(client_session_mock, auth_api_client, datamesh, event_loop):
+    lm1, lm2, relationship = datamesh
+    factories.JoinRecord(relationship=relationship,
+                         record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
+                         related_record_id=1, related_record_uuid=None)
+
+    url = f'/async/{lm1.endpoint_name}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/'
+
+    # mock aiohttp responses
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json'), 'rb') as r:
+        swagger_location_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
+        swagger_documents_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/data_detail_siteprofile.json'), 'rb') as r:
+        data_location_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/data_detail_document.json'), 'rb') as r:
+        data_documents_body = r.read()
+    responses = [
+        AiohttpResponseMock(method='GET', url=f'{lm1.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_location_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm2.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_documents_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm1.endpoint}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/',
+                            status=200,
+                            body=data_location_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm2.endpoint}/documents/1/', status=200,
+                            body=data_documents_body, headers={'Content-Type': 'application/json'}),
+    ]
+    client_session_mock.return_value = create_aiohttp_session_mock(responses, loop=event_loop)
+
+    # make api request
+    response = auth_api_client.get(url, {'join': 'true'})
+
+    assert response.status_code == 200
+    assert response.has_header('Content-Type')
+    assert response.get('Content-Type') == 'application/json'
+    data = response.json()
+    assert relationship.key in data
+    assert len(data[relationship.key]) == 1
+    assert data[relationship.key][0]['id'] == 1
+
+
+@pytest.mark.django_db()
+@patch('gateway.request.aiohttp.ClientSession')
+def test_make_service_request_with_datamesh_list(client_session_mock, auth_api_client, datamesh, event_loop):
+    lm1, lm2, relationship = datamesh
+    factories.JoinRecord(relationship=relationship,
+                         record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
+                         related_record_id=1, related_record_uuid=None)
+
+    url = f'/async/{lm1.endpoint_name}/siteprofiles/'
+
+    # mock requests
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json'), 'rb') as r:
+        swagger_location_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
+        swagger_documents_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/data_list_siteprofile.json'), 'rb') as r:
+        data_location_body = r.read()
+    with open(os.path.join(CURRENT_PATH, 'fixtures/data_detail_document.json'), 'rb') as r:
+        data_documents_body = r.read()
+    responses = [
+        AiohttpResponseMock(method='GET', url=f'{lm1.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_location_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm2.endpoint}/docs/swagger.json', status=200,
+                            body=swagger_documents_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm1.endpoint}/siteprofiles/', status=200,
+                            body=data_location_body, headers={'Content-Type': 'application/json'}),
+        AiohttpResponseMock(method='GET', url=f'{lm2.endpoint}/documents/1/', status=200,
+                            body=data_documents_body, headers={'Content-Type': 'application/json'}),
+    ]
+    client_session_mock.return_value = create_aiohttp_session_mock(responses, loop=event_loop)
+
+    # make api request
+    response = auth_api_client.get(url, {'join': 'true'})
+
+    assert response.status_code == 200
+    assert response.has_header('Content-Type')
+    assert response.get('Content-Type') == 'application/json'
+    data = response.json()
+
+    # first item in the list has a joined record
+    item1 = data["results"][0]
+    assert relationship.key in item1
+    assert len(item1[relationship.key]) == 1
+    assert item1[relationship.key][0]['id'] == 1
+
+    # second item in the list doesn't have a joined record
+    item2 = data["results"][1]
+    assert relationship.key in item2
+    assert len(item2[relationship.key]) == 0

--- a/gateway/tests/test_views_beta.py
+++ b/gateway/tests/test_views_beta.py
@@ -12,11 +12,12 @@ from .fixtures import logic_module, datamesh
 CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
+@pytest.mark.parametrize("content,content_type", [('{"details": "IT IS A TEST"}', 'application/json'),
+                                                  ('IT IS A TEST', 'text/html; charset=utf-8')])
 @pytest.mark.django_db()
 @httpretty.activate
-def test_make_service_request_data_and_raw(auth_api_client, logic_module):
+def test_make_service_request_data_and_raw(auth_api_client, logic_module, content, content_type):
     url = f'/{logic_module.endpoint_name}/thumbnail/1/'
-    content = '{"details": "IT IS A TEST"}'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json')) as r:
@@ -31,7 +32,7 @@ def test_make_service_request_data_and_raw(auth_api_client, logic_module):
         httpretty.GET,
         f'{logic_module.endpoint}/thumbnail/1/',
         body=content,
-        adding_headers={'Content-Type': 'application/json'}
+        adding_headers={'Content-Type': content_type}
     )
 
     # make api request
@@ -40,39 +41,7 @@ def test_make_service_request_data_and_raw(auth_api_client, logic_module):
     assert response.status_code == 200
     assert response.content == content.encode()
     assert response.has_header('Content-Type')
-    assert response.get('Content-Type') == 'application/json'
-
-
-@pytest.mark.django_db()
-@httpretty.activate
-def test_make_service_request_only_raw(auth_api_client, logic_module):
-
-    url = f'/{logic_module.endpoint_name}/thumbnail/1/'
-    content = 'IT IS A TEST'
-
-    # mock requests
-    with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json')) as r:
-        swagger_body = r.read()
-    httpretty.register_uri(
-        httpretty.GET,
-        f'{logic_module.endpoint}/docs/swagger.json',
-        body=swagger_body,
-        adding_headers={'Content-Type': 'application/json'}
-    )
-    httpretty.register_uri(
-        httpretty.GET,
-        f'{logic_module.endpoint}/thumbnail/1/',
-        body=content,
-        adding_headers={'Content-Type': 'text/html; charset=utf-8'}
-    )
-
-    # make api request
-    response = auth_api_client.get(url)
-
-    assert response.status_code == 200
-    assert response.content == content.encode()
-    assert response.has_header('Content-Type')
-    assert response.get('Content-Type') == 'text/html; charset=utf-8'
+    assert response.get('Content-Type') == content_type
 
 
 @pytest.mark.django_db()

--- a/gateway/tests/utils.py
+++ b/gateway/tests/utils.py
@@ -1,0 +1,60 @@
+import typing
+import asyncio
+import json
+from unittest.mock import Mock
+
+from aiohttp import ClientSession, StreamReader
+
+
+class AiohttpResponseMock:
+
+    def __init__(self, method, url, status, body, headers=None):
+        self.method = method
+        self.url = url
+        self.status = status
+        self.body = body
+        self._headers = headers or {}
+
+    def match_request(self, method, url):
+        # URLs should exactly match (incl. order of query params), TODO: make more intelligent URL matching
+        if method.lower() == self.method.lower() and url.lower() == self.url.lower():
+            return True
+        return False
+
+    @property
+    def headers(self):
+        return self._headers
+
+    @property
+    def content(self):
+        protocol = Mock(_reading_paused=False)
+        stream = StreamReader(protocol)
+        stream.feed_data(self.body)
+        stream.feed_eof()
+        return stream
+
+    @asyncio.coroutine
+    def text(self, encoding='utf-8'):
+        return self.body.decode(encoding)
+
+    @asyncio.coroutine
+    def json(self, encoding='utf-8'):
+        return json.loads(self.body.decode(encoding))
+
+    @asyncio.coroutine
+    def release(self):
+        pass
+
+
+def create_aiohttp_session_mock(response_mocks: typing.Iterable[AiohttpResponseMock],
+                                loop: asyncio.AbstractEventLoop = None) -> ClientSession:
+
+    async def _request(method, url, *args, **kwargs):
+        for response in response_mocks:
+            if response.match_request(method, url):
+                return response
+        assert False, f'No response mock for {method} {url}'
+
+    session = ClientSession(loop=loop)
+    session._request = _request
+    return session

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,3 +6,4 @@ pytest==5.0.0
 pytest-django==3.5.1
 pytest-cov==2.7.1
 httpretty==0.9.6
+pytest-asyncio==0.10.0


### PR DESCRIPTION
## Purpose
Tests for async gateway

## Approach
Create class for mocking aiohttp client Responses, and mock ClientSession with the use of this fake responses.
All tests are the same as for sync gateway.