### PR TITLE
PLAT-557: DataMesh service for decoupling from gateway

### DIFF
--- a/datamesh/services.py
+++ b/datamesh/services.py
@@ -1,0 +1,137 @@
+import typing
+import logging
+import asyncio
+
+from .models import LogicModuleModel, JoinRecord
+from .utils import prepare_lookup_kwargs
+
+logger = logging.getLogger(__name__)
+
+
+class DataMesh:
+    """
+    Encapsulates aggregation of data from different services (logic modules).
+    For each model DataMesh object should be created.
+    """
+
+    def __init__(self, logic_module_endpoint: str, model_endpoint: str):
+        self._logic_module_model = LogicModuleModel.objects.get(logic_module_endpoint_name=logic_module_endpoint,
+                                                                endpoint=model_endpoint)
+        self._relationships = self._logic_module_model.get_relationships()
+        self._origin_lookup_field = self._logic_module_model.lookup_field_name
+
+    @property
+    def related_logic_modules(self) -> list:
+        """
+        Gets a list of logic modules names that are related to current model
+        """
+        modules_list = [relationship.related_model.logic_module_endpoint_name
+                        for relationship, _ in self._relationships]
+        return list(dict.fromkeys(modules_list))
+
+    def get_related_records_meta(self, origin_pk: typing.Any) -> typing.Generator[int, None, None]:
+        """
+        Gets list of related records' META-data that is used for retrieving data for each of these records
+        """
+        for relationship, is_forward_lookup in self._relationships:
+            join_records = JoinRecord.objects.get_join_records(origin_pk, relationship, is_forward_lookup)
+            if join_records:
+                related_model, related_record_field = prepare_lookup_kwargs(
+                    is_forward_lookup, relationship, join_records[0])
+
+                for join_record in join_records:
+
+                    yield {
+                        'relationship_key': relationship.key,
+                        'params': {
+                            'pk': (str(getattr(join_record, related_record_field))),
+                            'model': related_model.endpoint.strip('/'),
+                            'service': related_model.logic_module_endpoint_name,
+                        }
+                    }
+
+    def extend_data(self, data: typing.Union[dict, list], client: typing.Any, asynchronous: bool = False):
+        """
+        Extends given data according to this DataMesh's relationships.
+        For getting extended data it uses a client object.
+        """
+        if asynchronous:
+            asyncio.run(self._async_extend_data(data, client))
+        else:
+            if isinstance(data, dict):
+                # one-object JSON
+                self._add_nested_data(data, client)
+            elif isinstance(data, list):
+                # many-objects JSON
+                for data_item in data:
+                    self._add_nested_data(data_item, client)
+
+    def _add_nested_data(self, data_item: dict, client: typing.Any) -> None:
+        """
+        Nest data retrieved from related services.
+        """
+        origin_pk = data_item.get(self._origin_lookup_field)
+        if not origin_pk:
+            raise KeyError(
+                f'DataMesh Error: lookup_field_name "{self._origin_lookup_field}" not found in response.'
+            )
+
+        for meta in self.get_related_records_meta(origin_pk):
+            request_kwargs = meta['params']
+            request_kwargs['method'] = 'get'
+            relationship_key = meta['relationship_key']
+            if relationship_key not in data_item:
+                data_item[relationship_key] = []
+
+            if hasattr(client, 'request') and callable(client.request):
+                content = client.request(**request_kwargs)
+                if isinstance(content, dict):
+                    data_item[relationship_key].append(dict(content))
+                else:
+                    logger.error(f'No response data for join record (request params: {request_kwargs})')
+            else:
+                raise AttributeError(f'DataMesh Error: Client should have request method')
+
+    async def _async_extend_data(self, data, client):
+        """
+        Wraps async aggregation logic
+        """
+        tasks = []
+        if isinstance(data, dict):
+            # detailed view
+            tasks.extend(await self._prepare_tasks(data, client))
+        elif isinstance(data, list):
+            # list view
+            for data_item in data:
+                tasks.extend(await self._prepare_tasks(data_item, client))
+        await asyncio.gather(*tasks)
+
+    async def _prepare_tasks(self, data_item: dict, client: typing.Any) -> list:
+        """ Creates a list of coroutines for extending data from other services asynchronously """
+        tasks = []
+
+        origin_pk = data_item.get(self._origin_lookup_field)
+        if not origin_pk:
+            raise KeyError(
+                f'DataMesh Error: lookup_field_name "{self._origin_lookup_field}" not found in response.'
+            )
+
+        for meta in self.get_related_records_meta(origin_pk):
+            request_kwargs = meta['params']
+            request_kwargs['method'] = 'get'
+            relationship_key = meta['relationship_key']
+            if relationship_key not in data_item:
+                data_item[relationship_key] = []
+
+            tasks.append(self._extend_content(client, data_item[relationship_key], **request_kwargs))
+
+        return tasks
+
+    async def _extend_content(self, client: typing.Any, placeholder: list, **request_kwargs) -> None:
+        """ Performs data request and extends data with received data """
+
+        content = await client.request(**request_kwargs)
+        if isinstance(content, dict):
+            placeholder.append(dict(content))
+        else:
+            logger.error(f'No response data for join record (request params: {request_kwargs})')

--- a/datamesh/tests/fixtures.py
+++ b/datamesh/tests/fixtures.py
@@ -87,12 +87,3 @@ def appointment_logic_module_model():
         logic_module_endpoint_name='crm',
         model='Appointment'
     )
-
-
-def service_response_mock(data):
-    headers = {'Content-Type': ['application/json']}
-    service_response = Mock(PySwaggerResponse)
-    service_response.status = 200
-    service_response.header = headers
-    service_response.data = data
-    return service_response

--- a/datamesh/tests/test_datamesh_service.py
+++ b/datamesh/tests/test_datamesh_service.py
@@ -1,0 +1,209 @@
+import pytest
+
+import factories
+from datamesh.tests.fixtures import relationship, relationship2, relationship_with_10_records, org
+from datamesh.services import DataMesh
+
+
+@pytest.mark.django_db()
+class TestSyncDataMesh:
+
+    def test_join_data_one_obj_w_relationships(self, relationship):
+        factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
+                             record_uuid=None, related_record_uuid=None)
+
+        logic_module_model = relationship.origin_model
+        data = {'id': 1, 'name': 'test', 'contact_uuid': 1}
+
+        # mock client for related logic module
+        class ClientMock:
+            def request(self, **kwargs):
+                return {'id': 1, 'file': '/somewhere/128/',}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client)
+
+        # validate result
+        expected_data = {
+            'id': 1,
+            'name': 'test',
+            'contact_uuid': 1,
+            relationship.key: [{
+                'id': 1,
+                'file': '/somewhere/128/',
+            }]
+        }
+
+        assert data == expected_data
+
+    @pytest.mark.django_db()
+    def test_join_data_one_obj_w_two_relationships(self, relationship, relationship2, org):
+        factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
+                             record_uuid=None, related_record_uuid=None)
+        factories.JoinRecord(relationship=relationship2, record_id=1, related_record_id=10,
+                             record_uuid=None, related_record_uuid=None)
+
+        logic_module_model = relationship.origin_model
+        data = {'id': 1, 'name': 'test', 'contact_uuid': 1}
+
+        # mock client for related services
+        class ClientMock:
+            def request(self, **kwargs):
+                if kwargs['model'] == 'documents':
+                    return {'id': 2, 'file': '/documents/128/'}
+                if kwargs['model'] == 'siteprofile':
+                    return {'id': 10, 'city': 'New York'}
+                return {}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client)
+
+        # validate result
+        expected_data = {
+            'id': 1,
+            'name': 'test',
+            'contact_uuid': 1,
+            relationship.key: [{
+                'id': 2,
+                'file': '/documents/128/',
+            }],
+            relationship2.key: [{
+                'id': 10,
+                'city': 'New York',
+            }]
+        }
+
+        assert data == expected_data
+
+    @pytest.mark.django_db()
+    def test_join_data_list(self, relationship_with_10_records):
+        join_records = relationship_with_10_records.joinrecords.all()
+
+        logic_module_model = relationship_with_10_records.origin_model
+
+        data = [{'uuid': str(item.record_uuid), 'name': f'Boiler #{i}'} for i, item in enumerate(join_records)]
+
+        # mock client for related logic module
+        mocked_response_data = {str(item.related_record_uuid): '/documents/128/' for item in join_records}
+
+        class ClientMock:
+            def request(self, **kwargs):
+                return {'uuid': kwargs['pk'], 'file': mocked_response_data[kwargs['pk']]}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client)
+
+        for i, item in enumerate(data):
+            assert item['uuid'] == str(join_records[i].record_uuid)
+            assert relationship_with_10_records.key in item
+            nested = item[relationship_with_10_records.key]
+            assert len(nested) == 1
+            assert nested[0]['uuid'] == str(join_records[i].related_record_uuid)
+
+
+@pytest.mark.django_db()
+class TestAsyncDataMesh:
+
+    def test_join_data_one_obj_w_relationships(self, relationship):
+        factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
+                             record_uuid=None, related_record_uuid=None)
+
+        logic_module_model = relationship.origin_model
+        data = {'id': 1, 'name': 'test', 'contact_uuid': 1}
+
+        # mock client for related logic module
+        class ClientMock:
+            async def request(self, **kwargs):
+                return {'id': 1, 'file': '/somewhere/128/',}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client, asynchronous=True)
+
+        # validate result
+        expected_data = {
+            'id': 1,
+            'name': 'test',
+            'contact_uuid': 1,
+            relationship.key: [{
+                'id': 1,
+                'file': '/somewhere/128/',
+            }]
+        }
+
+        assert data == expected_data
+
+    @pytest.mark.django_db()
+    def test_join_data_one_obj_w_two_relationships(self, relationship, relationship2, org):
+        factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
+                             record_uuid=None, related_record_uuid=None)
+        factories.JoinRecord(relationship=relationship2, record_id=1, related_record_id=10,
+                             record_uuid=None, related_record_uuid=None)
+
+        logic_module_model = relationship.origin_model
+        data = {'id': 1, 'name': 'test', 'contact_uuid': 1}
+
+        # mock client for related services
+        class ClientMock:
+            async def request(self, **kwargs):
+                if kwargs['model'] == 'documents':
+                    return {'id': 2, 'file': '/documents/128/'}
+                if kwargs['model'] == 'siteprofile':
+                    return {'id': 10, 'city': 'New York'}
+                return {}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client, asynchronous=True)
+
+        # validate result
+        expected_data = {
+            'id': 1,
+            'name': 'test',
+            'contact_uuid': 1,
+            relationship.key: [{
+                'id': 2,
+                'file': '/documents/128/',
+            }],
+            relationship2.key: [{
+                'id': 10,
+                'city': 'New York',
+            }]
+        }
+
+        assert data == expected_data
+
+    @pytest.mark.django_db()
+    def test_join_data_list(self, relationship_with_10_records):
+        join_records = relationship_with_10_records.joinrecords.all()
+
+        logic_module_model = relationship_with_10_records.origin_model
+
+        data = [{'uuid': str(item.record_uuid), 'name': f'Boiler #{i}'} for i, item in enumerate(join_records)]
+
+        # mock client for related logic module
+        mocked_response_data = {str(item.related_record_uuid): '/documents/128/' for item in join_records}
+
+        class ClientMock:
+            async def request(self, **kwargs):
+                return {'uuid': kwargs['pk'], 'file': mocked_response_data[kwargs['pk']]}
+        client = ClientMock()
+
+        datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
+                            model_endpoint=logic_module_model.endpoint)
+        datamesh.extend_data(data, client, asynchronous=True)
+
+        for i, item in enumerate(data):
+            assert item['uuid'] == str(join_records[i].record_uuid)
+            assert relationship_with_10_records.key in item
+            nested = item[relationship_with_10_records.key]
+            assert len(nested) == 1
+            assert nested[0]['uuid'] == str(join_records[i].related_record_uuid)

--- a/datamesh/tests/test_join.py
+++ b/datamesh/tests/test_join.py
@@ -2,11 +2,10 @@ import json
 from unittest.mock import Mock, patch
 
 import pytest
-from pyswagger import App
 from bravado_core.spec import Spec
 
 import factories
-from datamesh.tests.fixtures import relationship, relationship2, relationship_with_10_records, service_response_mock
+from datamesh.tests.fixtures import relationship, relationship2, relationship_with_10_records
 from workflow.tests.fixtures import auth_api_client, org
 
 


### PR DESCRIPTION
## Purpose
Decoupling of DataMesh and Gateway

## Approach
DataMesh class is created. The instance of this class is created for each data model, and it performs all the datamesh operations with this model.
For getting the data from related services we should pass a `client` object. This object should have `request` method. The implementation of the "client" object is outside the the DataMesh, but it could be synchronous or asynchronous. Depending on this the aggregation in DataMesh performed in different ways.
Also I wrote the tests with mocked client.
The next step will be the integration of this DataMesh class in the gateway and implementation of the clients.