### PR TITLE
PLAT-557: allow async extend_data to call from outer event loop

### DIFF
--- a/datamesh/services.py
+++ b/datamesh/services.py
@@ -50,21 +50,18 @@ class DataMesh:
                         }
                     }
 
-    def extend_data(self, data: typing.Union[dict, list], client: typing.Any, asynchronous: bool = False):
+    def extend_data(self, data: typing.Union[dict, list], client: typing.Any) -> None:
         """
         Extends given data according to this DataMesh's relationships.
         For getting extended data it uses a client object.
         """
-        if asynchronous:
-            asyncio.run(self._async_extend_data(data, client))
-        else:
-            if isinstance(data, dict):
-                # one-object JSON
-                self._add_nested_data(data, client)
-            elif isinstance(data, list):
-                # many-objects JSON
-                for data_item in data:
-                    self._add_nested_data(data_item, client)
+        if isinstance(data, dict):
+            # one-object JSON
+            self._add_nested_data(data, client)
+        elif isinstance(data, list):
+            # many-objects JSON
+            for data_item in data:
+                self._add_nested_data(data_item, client)
 
     def _add_nested_data(self, data_item: dict, client: typing.Any) -> None:
         """
@@ -92,9 +89,9 @@ class DataMesh:
             else:
                 raise AttributeError(f'DataMesh Error: Client should have request method')
 
-    async def _async_extend_data(self, data, client):
+    async def async_extend_data(self, data: typing.Union[dict, list], client: typing.Any):
         """
-        Wraps async aggregation logic
+        Async aggregation logic
         """
         tasks = []
         if isinstance(data, dict):

--- a/datamesh/tests/test_datamesh_service.py
+++ b/datamesh/tests/test_datamesh_service.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 import factories
@@ -125,7 +127,8 @@ class TestAsyncDataMesh:
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client, asynchronous=True)
+
+        asyncio.run(datamesh.async_extend_data(data, client))
 
         # validate result
         expected_data = {
@@ -162,7 +165,7 @@ class TestAsyncDataMesh:
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client, asynchronous=True)
+        asyncio.run(datamesh.async_extend_data(data, client))
 
         # validate result
         expected_data = {
@@ -199,7 +202,7 @@ class TestAsyncDataMesh:
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client, asynchronous=True)
+        asyncio.run(datamesh.async_extend_data(data, client))
 
         for i, item in enumerate(data):
             assert item['uuid'] == str(join_records[i].record_uuid)


### PR DESCRIPTION
## Purpose
It's impossible to create another event loop in the running event loop, so we shouldn't create event loop inside DataMesh object.

## Approach
Make async_extend_data public, so we could call this coroutine from outside.
