### PR TITLE
Change relationship name in data mesh load script

### DIFF
--- a/datamesh/management/commands/loadrelationships.py
+++ b/datamesh/management/commands/loadrelationships.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         relationship, _ = Relationship.objects.get_or_create(
             origin_model=origin_model,
             related_model=related_model,
-            key='siteprofile_relationship'
+            key='contact_siteprofile_relationship'
         )
         eligible_join_records = []
         # create JoinRecords with contact.id and siteprofile_uuid for all contacts


### PR DESCRIPTION
## Purpose
The internal convention for `Relationship.key`-field-names is `<model1name>_<model2name>_relationship`.

## Approach
Adapt name in load-script for contacts and siteprofiles to `contact_siteprofile_relationship`.