### PR TITLE
 PLAT-557: Gateway refactoring to use DataMesh object

### DIFF
--- a/datamesh/tests/test_datamesh_service.py
+++ b/datamesh/tests/test_datamesh_service.py
@@ -21,11 +21,11 @@ class TestSyncDataMesh:
         class ClientMock:
             def request(self, **kwargs):
                 return {'id': 1, 'file': '/somewhere/128/',}
-        client = ClientMock()
+        client_map = {relationship.related_model.logic_module_endpoint_name: ClientMock()}
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client)
+        datamesh.extend_data(data, client_map)
 
         # validate result
         expected_data = {
@@ -58,11 +58,14 @@ class TestSyncDataMesh:
                 if kwargs['model'] == 'siteprofile':
                     return {'id': 10, 'city': 'New York'}
                 return {}
-        client = ClientMock()
+        client_map = {
+            relationship.related_model.logic_module_endpoint_name: ClientMock(),
+            relationship2.related_model.logic_module_endpoint_name: ClientMock(),
+        }
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client)
+        datamesh.extend_data(data, client_map)
 
         # validate result
         expected_data = {
@@ -95,11 +98,11 @@ class TestSyncDataMesh:
         class ClientMock:
             def request(self, **kwargs):
                 return {'uuid': kwargs['pk'], 'file': mocked_response_data[kwargs['pk']]}
-        client = ClientMock()
+        client_map = {relationship_with_10_records.related_model.logic_module_endpoint_name: ClientMock()}
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        datamesh.extend_data(data, client)
+        datamesh.extend_data(data, client_map)
 
         for i, item in enumerate(data):
             assert item['uuid'] == str(join_records[i].record_uuid)
@@ -123,12 +126,12 @@ class TestAsyncDataMesh:
         class ClientMock:
             async def request(self, **kwargs):
                 return {'id': 1, 'file': '/somewhere/128/',}
-        client = ClientMock()
+        client_map = {relationship.related_model.logic_module_endpoint_name: ClientMock()}
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
 
-        asyncio.run(datamesh.async_extend_data(data, client))
+        asyncio.run(datamesh.async_extend_data(data, client_map))
 
         # validate result
         expected_data = {
@@ -161,11 +164,14 @@ class TestAsyncDataMesh:
                 if kwargs['model'] == 'siteprofile':
                     return {'id': 10, 'city': 'New York'}
                 return {}
-        client = ClientMock()
+        client_map = {
+            relationship.related_model.logic_module_endpoint_name: ClientMock(),
+            relationship2.related_model.logic_module_endpoint_name: ClientMock(),
+        }
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        asyncio.run(datamesh.async_extend_data(data, client))
+        asyncio.run(datamesh.async_extend_data(data, client_map))
 
         # validate result
         expected_data = {
@@ -198,11 +204,11 @@ class TestAsyncDataMesh:
         class ClientMock:
             async def request(self, **kwargs):
                 return {'uuid': kwargs['pk'], 'file': mocked_response_data[kwargs['pk']]}
-        client = ClientMock()
+        client_map = {relationship_with_10_records.related_model.logic_module_endpoint_name: ClientMock()}
 
         datamesh = DataMesh(logic_module_endpoint=logic_module_model.logic_module_endpoint_name,
                             model_endpoint=logic_module_model.endpoint)
-        asyncio.run(datamesh.async_extend_data(data, client))
+        asyncio.run(datamesh.async_extend_data(data, client_map))
 
         for i, item in enumerate(data):
             assert item['uuid'] == str(join_records[i].record_uuid)

--- a/datamesh/tests/test_join.py
+++ b/datamesh/tests/test_join.py
@@ -11,7 +11,7 @@ from workflow.tests.fixtures import auth_api_client, org
 
 @pytest.mark.django_db()
 @patch('gateway.request.GatewayRequest._get_swagger_spec')
-@patch('gateway.request.GatewayRequest._data_request')
+@patch('gateway.request.SwaggerClient.request')
 def test_join_data_one_obj_w_relationships(mock_perform_request, mock_spec, auth_api_client, relationship):
     factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
                          record_uuid=None, related_record_uuid=None)
@@ -47,7 +47,7 @@ def test_join_data_one_obj_w_relationships(mock_perform_request, mock_spec, auth
 
 @pytest.mark.django_db()
 @patch('gateway.request.GatewayRequest._get_swagger_spec')
-@patch('gateway.request.GatewayRequest._data_request')
+@patch('gateway.request.SwaggerClient.request')
 def test_join_data_one_obj_w_two_relationships(mock_perform_request, mock_spec, auth_api_client,
                                                relationship, relationship2):
     factories.JoinRecord(relationship=relationship, record_id=1, related_record_id=2,
@@ -92,7 +92,7 @@ def test_join_data_one_obj_w_two_relationships(mock_perform_request, mock_spec, 
 
 @pytest.mark.django_db()
 @patch('gateway.request.GatewayRequest._get_swagger_spec')
-@patch('gateway.request.GatewayRequest._data_request')
+@patch('gateway.request.SwaggerClient.request')
 def test_join_data_list(mock_perform_request, mock_spec, auth_api_client, relationship_with_10_records, org):
     mock_spec.return_value = Mock(Spec)
 

--- a/gateway/clients.py
+++ b/gateway/clients.py
@@ -1,0 +1,171 @@
+import logging
+import json
+from typing import Any, Dict, Tuple
+
+import requests
+import aiohttp
+from django.http.request import QueryDict
+from bravado_core.spec import Spec
+from rest_framework.request import Request
+from rest_framework.authentication import get_authorization_header
+
+from . import exceptions
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+class BaseSwaggerClient:
+    """ Base for client class that is responsible for retrieving data from the service with Swagger spec"""
+
+    def __init__(self, spec: Spec, incoming_request: Request):
+        self._spec = spec
+        self._in_request = incoming_request
+        self._data = dict()
+
+    def request(self, **kwargs):
+        raise NotImplementedError()
+
+    def is_valid_for_cache(self) -> bool:
+        """ Checks if request is valid for caching operations """
+        return self._in_request.method.lower() == 'get' and not self._in_request.query_params
+
+    def prepare_data(self, spec: Spec, **kwargs) -> Tuple[str, str]:
+        """ Parse request URL, validates operation, and returns method and URL for outgoing request"""
+
+        # Parse URL kwargs
+        pk = kwargs.get('pk')
+        model = kwargs.get('model', '').lower()
+        path_kwargs = {}
+        if kwargs.get('pk') is None:
+            path = f'/{model}/'
+        else:
+            pk_name = 'uuid' if utils.valid_uuid4(pk) else 'id'
+            path_kwargs = {pk_name: pk}
+            path = f'/{model}/{{{pk_name}}}/'
+
+        # Check that operation is valid according to spec
+        operation = spec.get_op_for_request(self._in_request.method, path)
+        if not operation:
+            raise exceptions.EndpointNotFound(f'Endpoint not found: {self._in_request.method} {path}')
+        method = operation.http_method.lower()
+        path_name = operation.path_name
+
+        # Build URL for the operation to request data from the service
+        url = spec.api_url.rstrip('/') + path_name
+        for k, v in path_kwargs.items():
+            url = url.replace(f'{{{k}}}', v)
+
+        return method, url
+
+    def get_request_data(self) -> dict:
+        """
+        Create the data structure to be used in Swagger request. GET and  DELETE
+        requests don't require body, so the data structure will have just
+        query parameters if passed to swagger request.
+        """
+        if self._in_request.content_type == 'application/json':
+            return json.dumps(self._in_request.data)
+
+        method = self._in_request.META['REQUEST_METHOD'].lower()
+        data = self._in_request.query_params.dict()
+
+        data.pop('aggregate', None)
+        data.pop('join', None)
+
+        if method in ['post', 'put', 'patch']:
+            query_dict_body = self._in_request.data if hasattr(self._in_request, 'data') else dict()
+            body = query_dict_body.dict() if isinstance(query_dict_body, QueryDict) else query_dict_body
+            data.update(body)
+
+            # handle uploaded files
+            if self._in_request.FILES:
+                for key, value in self._in_request.FILES.items():
+                    data[key] = {
+                        'header': {
+                            'Content-Type': value.content_type,
+                        },
+                        'data': value,
+                        'filename': value.name,
+                    }
+
+        return data
+
+    def get_headers(self) -> dict:
+        """Get data and headers from the incoming request."""
+        headers = {
+            'Authorization': get_authorization_header(self._in_request).decode('utf-8'),
+        }
+        if self._in_request.content_type == 'application/json':
+            headers['content-type'] = 'application/json'
+        return headers
+
+
+class SwaggerClient(BaseSwaggerClient):
+    """ Synchronous implementation of Swagger client using requests lib """
+
+    def request(self, **kwargs) -> Tuple[Any, int, Dict[str, str]]:
+        """
+        Perform request to the service, use Swagger spec for validating operation
+        """
+
+        method, url = self.prepare_data(self._spec, **kwargs)
+
+        # Check request cache if applicable
+        if self.is_valid_for_cache() and url in self._data:
+            logger.debug(f'Taking data from cache: {url}')
+            return self._data[url]
+
+        # Make request to the service
+        method = getattr(requests, method)
+        try:
+            response = method(url,
+                              headers=self.get_headers(),
+                              params=self._in_request.query_params,
+                              data=self.get_request_data(),
+                              files=self._in_request.FILES)
+        except Exception as e:
+            error_msg = (f'An error occurred when redirecting the request to '
+                         f'or receiving the response from the service.\n'
+                         f'Origin: ({e.__class__.__name__}: {e})')
+            raise exceptions.GatewayError(error_msg)
+
+        try:
+            content = response.json()
+        except ValueError:
+            content = response.content
+        return_data = (content, response.status_code, response.headers)
+
+        # Cache data if request is cache-valid
+        if self.is_valid_for_cache():
+            self._data[url] = return_data
+
+        return return_data
+
+
+class AsyncSwaggerClient(BaseSwaggerClient):
+    """ Asynchronous implementation of Swagger client using aiohttp lib """
+
+    async def request(self, **kwargs) -> Tuple[Any, int, Dict[str, str]]:
+        method, url = self.prepare_data(self._spec, **kwargs)
+
+        # Check request cache if applicable
+        if self.is_valid_for_cache() and url in self._data:
+            logger.debug(f'Taking data from cache: {url}')
+            return self._data[url]
+
+        # Make request to the service
+        async with aiohttp.ClientSession() as session:
+            method = getattr(session, method)
+            async with method(url, data=self.get_request_data(), headers=self.get_headers()) as response:
+                try:
+                    content = await response.json()
+                except json.JSONDecodeError:
+                    content = await response.content.read()
+            return_data = (content, response.status, response.headers)
+
+        # Cache data if request is cache-valid
+        if self.is_valid_for_cache():
+            self._data[url] = return_data
+
+        return return_data


### PR DESCRIPTION
## Purpose
Decoupling of DataMesh and Gateway

## Approach
Continuing https://github.com/Humanitec/bifrost/pull/157.
1) Implement clients for inject into DataMesh object
2) In DataMesh - use client_map dict instead of single client, to allow using different clients for different services.
3) Refactoring GatewayRequest to use DataMesh object for aggregating.
