### PR TITLE
PLAT-567: endpoints for Data Mesh models

### DIFF
--- a/datamesh/serializers.py
+++ b/datamesh/serializers.py
@@ -5,6 +5,25 @@ from rest_framework import serializers
 from datamesh.models import JoinRecord, Relationship, LogicModuleModel
 
 
+class LogicModuleModelSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = LogicModuleModel
+        fields = '__all__'
+
+
+class RelationshipSerializer(serializers.ModelSerializer):
+
+    origin_model = LogicModuleModelSerializer(read_only=True)
+    related_model = LogicModuleModelSerializer(read_only=True)
+    origin_model_id = serializers.UUIDField(write_only=True)
+    related_model_id = serializers.UUIDField(write_only=True)
+
+    class Meta:
+        model = Relationship
+        fields = '__all__'
+
+
 class JoinRecordSerializer(serializers.ModelSerializer):
     """
     The model_choices are created based on the logic_module__name as a prefix and the model name.

--- a/datamesh/urls.py
+++ b/datamesh/urls.py
@@ -6,5 +6,7 @@ from . import views
 router = routers.SimpleRouter()
 
 router.register('joinrecords', views.JoinRecordViewSet)
+router.register('logicmodulemodels', views.LogicModuleModelViewSet)
+router.register('relationships', views.RelationshiplViewSet)
 
 urlpatterns = router.urls

--- a/datamesh/views.py
+++ b/datamesh/views.py
@@ -3,8 +3,21 @@ from rest_framework import viewsets
 
 from .filters import JoinRecordFilter
 from .mixins import OrganizationQuerySetMixin
-from .models import JoinRecord
-from .serializers import JoinRecordSerializer
+from .models import JoinRecord, LogicModuleModel, Relationship
+from .serializers import JoinRecordSerializer, LogicModuleModelSerializer, RelationshipSerializer
+from workflow.permissions import IsSuperUserOrReadOnly
+
+
+class LogicModuleModelViewSet(viewsets.ModelViewSet):
+    queryset = LogicModuleModel.objects.all()
+    serializer_class = LogicModuleModelSerializer
+    permission_classes = (IsSuperUserOrReadOnly,)
+
+
+class RelationshiplViewSet(viewsets.ModelViewSet):
+    queryset = Relationship.objects.all()
+    serializer_class = RelationshipSerializer
+    permission_classes = (IsSuperUserOrReadOnly,)
 
 
 class JoinRecordViewSet(OrganizationQuerySetMixin,

--- a/factories/datamesh_models.py
+++ b/factories/datamesh_models.py
@@ -13,6 +13,7 @@ from factories import Organization
 class LogicModuleModel(DjangoModelFactory):
     logic_module_endpoint_name = LazyAttribute(
         lambda o: ''.join(random.choices(string.ascii_uppercase + string.digits, k=16)))
+    lookup_field_name = 'id'
 
     class Meta:
         model = LogicModulModelM


### PR DESCRIPTION
## Purpose
We need to create endpoints for LogicModuleModel and Relationship models to be allow to manage them via API.

## Approach
View sets, serializers, tests - nothing special.
Data Mesh permissions are a topic of separate discussion, so for now the permission is `IsSuperUserOrReadOnly`.