### PR TITLE
fix drone tests failure

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -18,5 +18,6 @@ API_GATEWAY_RESERVED_NAMES = [
     'core',
     'logicmodule',
     'user',
-    'organization'
+    'organization',
+    'datamesh',
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ django-cors-headers==2.5.3
 pyswagger==0.8.39
 bravado-core==5.13.1
 drf-yasg==1.10.2
+ruamel.yaml==0.15.100
 requests==2.21.0
 aiohttp==3.5.4
 factory_boy==2.12.0


### PR DESCRIPTION
## Purpose
Drone tests started to fail.

## Approach
The reason was `ruamel.yaml` lib update to 0.16.0 version from 2019-07-25 (it's in `drf_yasg` lib dependencies as `ruamel.yaml>=0.15.34`). So I fixed the version in ruamel.yaml==0.15.100.
