### PR TITLE
Extend related_logic_modules in DataMesh with origins

### DIFF
--- a/datamesh/services.py
+++ b/datamesh/services.py
@@ -29,12 +29,16 @@ class DataMesh:
     @property
     def related_logic_modules(self) -> list:
         """
-        Gets a list of logic modules names that are related to current model (exclude local logic modules)
+        Gets a list of logic modules names that are related to current model (exclude local logic modules).
+        The origin_model has to be added for the symmetrical/reverse relationships.
         """
         if not hasattr(self, '_related_logic_modules'):
             modules_list = [relationship.related_model.logic_module_endpoint_name
                             for relationship, _ in self._relationships if not relationship.related_model.is_local]
-            self._related_logic_modules = list(dict.fromkeys(modules_list))
+            modules_list_reverse = [
+                relationship.origin_model.logic_module_endpoint_name
+                for relationship, _ in self._relationships if not relationship.origin_model.is_local]
+            self._related_logic_modules = list(dict.fromkeys(modules_list + modules_list_reverse))
         return self._related_logic_modules
 
     def get_related_records_meta(self, origin_pk: Any) -> Generator[tuple, None, None]:


### PR DESCRIPTION
## Purpose
When the Data Mesh tried to extend data reversely, a
DatameshConfigurationError occured because the client was not registered
for the origin logic_module (only for the related logic_module).

## Approach
Adding the origin logic_module to the client_map by extending the
related_logic_modules property fixed this issue.