### PR TITLE
Improve datamesh

### DIFF
--- a/datamesh/models.py
+++ b/datamesh/models.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Tuple, List
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import CheckConstraint, Q, UniqueConstraint
 
@@ -56,6 +57,15 @@ class Relationship(models.Model):
 
     def __str__(self):
         return f'{self.origin_model} -> {self.related_model}'
+
+    def validate_reverse_relationship_absence(self):
+        """Validate reverse relationship does not exist already."""
+        if self.__class__.objects.filter(origin_model=self.related_model, related_model=self.origin_model).count():
+            raise ValidationError("Reverse relationship already exists.")
+
+    def save(self, *args, **kwargs):
+        self.validate_reverse_relationship_absence()
+        super().save(*args, **kwargs)
 
     class Meta:
         unique_together = (

--- a/datamesh/services.py
+++ b/datamesh/services.py
@@ -38,7 +38,7 @@ class DataMesh:
             modules_list_reverse = [
                 relationship.origin_model.logic_module_endpoint_name
                 for relationship, _ in self._relationships if not relationship.origin_model.is_local]
-            self._related_logic_modules = list(dict.fromkeys(modules_list + modules_list_reverse))
+            self._related_logic_modules = set(modules_list + modules_list_reverse)
         return self._related_logic_modules
 
     def get_related_records_meta(self, origin_pk: Any) -> Generator[tuple, None, None]:

--- a/datamesh/tests/test_models.py
+++ b/datamesh/tests/test_models.py
@@ -1,12 +1,22 @@
 import uuid
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 
-from datamesh.models import JoinRecord
+from datamesh.models import JoinRecord, Relationship
 
 from workflow.tests.fixtures import org
 from .fixtures import relationship
+
+
+@pytest.mark.django_db()
+def test_fail_create_reverse_relationship(relationship):
+    with pytest.raises(ValidationError):
+        Relationship.objects.create(
+            related_model=relationship.origin_model,
+            origin_model=relationship.related_model
+        )
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Purpose
1. The creation of reverse relationships led to two relationship-fields in the objects.
2. The `related_logic_modules` could be simplified and having a logic_module twice in the list was possible by the data structure.

## Approach
1. Added a validation in the `save`-method of the model to suppress creation of reverse relationships.
2. Removed unnecessary `list(dict.from_dict(...))` and added a `set()` instead.