### PR TITLE
Fix ContentTypeError on empty responses with AsyncClient - PLAT-569

### DIFF
--- a/gateway/clients.py
+++ b/gateway/clients.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Tuple
 
 import requests
 import aiohttp
+from aiohttp import ContentTypeError
 from django.http.request import QueryDict
 from bravado_core.spec import Spec
 from rest_framework.request import Request
@@ -160,7 +161,7 @@ class AsyncSwaggerClient(BaseSwaggerClient):
             async with method(url, data=self.get_request_data(), headers=self.get_headers()) as response:
                 try:
                     content = await response.json()
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ContentTypeError):
                     content = await response.content.read()
             return_data = (content, response.status, response.headers)
 

--- a/gateway/tests/test_views_async.py
+++ b/gateway/tests/test_views_async.py
@@ -13,9 +13,11 @@ from .utils import AiohttpResponseMock, create_aiohttp_session_mock
 CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
-
-@pytest.mark.parametrize("content,content_type", [(b'{"details": "IT IS A TEST"}', 'application/json'),
-                                                  (b'IT IS A TEST', 'text/html; charset=utf-8')])
+@pytest.mark.parametrize("content,content_type", [
+    (b'{"details": "IT IS A TEST"}', 'application/json'),
+    (b'IT IS A TEST', 'text/html; charset=utf-8'),
+    (None, 'application/octet-stream'), ]
+)
 @pytest.mark.django_db()
 @patch('gateway.request.aiohttp.ClientSession')
 def test_make_service_request_data_and_raw(client_session_mock, auth_api_client, logic_module, content, content_type,
@@ -38,7 +40,10 @@ def test_make_service_request_data_and_raw(client_session_mock, auth_api_client,
     response = auth_api_client.get(url)
 
     assert response.status_code == 200
-    assert response.content == content
+    if content:
+        assert response.content == content
+    else:
+        assert response.content == b''
     assert response.has_header('Content-Type')
     assert response.get('Content-Type') == content_type
 

--- a/gateway/tests/utils.py
+++ b/gateway/tests/utils.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 from unittest.mock import Mock
 
-from aiohttp import ClientSession, StreamReader
+from aiohttp import ClientSession, StreamReader, ContentTypeError, RequestInfo
 
 
 class AiohttpResponseMock:
@@ -39,6 +39,8 @@ class AiohttpResponseMock:
 
     @asyncio.coroutine
     def json(self, encoding='utf-8'):
+        if not getattr(self.body, "decode", False):
+            raise ContentTypeError(request_info=RequestInfo(self.url, self.method, self.headers), history=[self])
         return json.loads(self.body.decode(encoding))
 
     @asyncio.coroutine


### PR DESCRIPTION
## Purpose
When deleting contacts an empty response was returned which resulted in an error in the AsyncGateway.

## Approach
Added the `ContentTypeError` the list of catched exceptions.

### Further Info
https://humanitec.atlassian.net/browse/PLAT-526
