### PR TITLE
Upgrade Django framework to 2.2.4 for security reasons

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 celery==4.3.0
-Django==2.2.3
+Django==2.2.4
 django-filter==2.1.0
 django-health-check==3.6.1
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.5.2#egg=django-oauth-toolkit-jwt


### PR DESCRIPTION
## Purpose
Upgrade Django framework to 2.2.4 for security reasons

## Approach
Run all the tests after updating the version of Django and double-checked basic functionalities.
