### PR TITLE
Dynamic superuser password

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of buildly and their defau
 | `USE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATOR`  | If true, checks the similarity between the password and a set of attributes of the user | None |
 | `USE_PASSWORD_COMMON_VALIDATOR`     | If true, checks whether the password occurs in a list of common passwords | None |
 | `USE_PASSWORD_NUMERIC_VALIDATOR`    | If true, checks whether the password isn’t entirely numeric | None |
+| `SUPER_USER_PASSWORD`               | Used to define the super user password when it's created for the first time | `admin` in Debug mode and None |
 
 Specify each parameter using `-e`, `--env`, and `--env-file` flags to set simple (non-array) environment variables to `docker run`. For example,
 

--- a/buildly/management/commands/loadinitialdata.py
+++ b/buildly/management/commands/loadinitialdata.py
@@ -72,16 +72,27 @@ class Command(BaseCommand):
 
     def _create_user(self):
         if not CoreUser.objects.filter(is_superuser=True).exists():
-            logger.info("Creating global CoreGroup")
-            su = CoreUser.objects.create_superuser(
-                first_name='System',
-                last_name='Admin',
-                username='admin',
-                email='admin@example.com',
-                password='ttmtola1977',
-                organization=self._default_org,
-            )
-            su.core_groups.add(self._su_group)
+            logger.info("Creating Super User")
+            user_password = None
+            if settings.DEBUG:
+                user_password = settings.SUPER_USER_PASSWORD if settings.SUPER_USER_PASSWORD else 'admin'
+            elif settings.SUPER_USER_PASSWORD:
+                user_password = settings.SUPER_USER_PASSWORD
+            else:
+                warning_msg = 'A password for the super user needs to be provided, otherwise, it is not created.'
+                logger.warning(warning_msg)
+                self.stdout.write(f'{warning_msg}')
+
+            if user_password is not None:
+                su = CoreUser.objects.create_superuser(
+                    first_name='System',
+                    last_name='Admin',
+                    username='admin',
+                    email='admin@example.com',
+                    password=user_password,
+                    organization=self._default_org,
+                )
+                su.core_groups.add(self._su_group)
 
     @transaction.atomic
     def handle(self, *args, **options):

--- a/buildly/settings/base.py
+++ b/buildly/settings/base.py
@@ -326,8 +326,9 @@ RABBIT_PORT = os.getenv('RABBIT_PORT')
 RABBIT_VHOST = os.getenv('RABBIT_VHOST')
 RABBIT_WALHALL_QUEUE = os.getenv('RABBIT_WALHALL_QUEUE')
 
-
-DEFAULT_ORG = os.getenv('DEFAULT_ORG', 'My organization')
+# User and Organization configuration
+SUPER_USER_PASSWORD = os.getenv('SUPER_USER_PASSWORD')
+DEFAULT_ORG = os.getenv('DEFAULT_ORG')
 
 if os.getenv('EMAIL_BACKEND') == 'SMTP':
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/buildly/tests/test_loadinitialdata.py
+++ b/buildly/tests/test_loadinitialdata.py
@@ -1,0 +1,99 @@
+import logging
+import sys
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TransactionTestCase, override_settings
+
+from oauth2_provider.models import Application
+from workflow.models import CoreGroup, CoreUser, Organization
+
+
+class DevNull(object):
+    def write(self, data):
+        pass
+
+
+class LoadInitialDataTest(TransactionTestCase):
+    def setUp(self):
+        # Disable loggers. Do notice that pdb or print won't work neither
+        self.old_stdout = sys.stdout
+        self.old_stderr = sys.stderr
+        sys.stdout = DevNull()
+        sys.stderr = DevNull()
+        logging.disable(logging.ERROR)
+
+    def tearDown(self):
+        sys.stdout = self.old_stdout
+        sys.stderr = self.old_stderr
+        logging.disable(logging.NOTSET)
+
+    @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='123')
+    @override_settings(OAUTH_CLIENT_SECRET='456')
+    def test_full_initial_data(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
+        assert CoreUser.objects.filter(is_superuser=True).count() == 1
+
+    @override_settings(DEBUG=True)
+    @override_settings(DEFAULT_ORG='')
+    @override_settings(OAUTH_CLIENT_ID='123')
+    @override_settings(OAUTH_CLIENT_SECRET='456')
+    def test_without_default_organization(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.all().count() == 0
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
+        assert CoreUser.objects.filter(is_superuser=True).count() == 1
+
+    @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='')
+    @override_settings(OAUTH_CLIENT_SECRET='')
+    def test_without_oauth_credentials(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
+        assert Application.objects.all().count() == 0
+        assert CoreUser.objects.filter(is_superuser=True).count() == 1
+
+    @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='123')
+    @override_settings(OAUTH_CLIENT_SECRET='456')
+    def test_create_user_debug_no_password(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
+        assert CoreUser.objects.filter(is_superuser=True).count() == 1
+
+    @override_settings(DEBUG=False)
+    @override_settings(OAUTH_CLIENT_ID='123')
+    @override_settings(OAUTH_CLIENT_SECRET='456')
+    def test_create_user_no_debug_no_password(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
+        assert CoreUser.objects.filter(is_superuser=True).count() == 0


### PR DESCRIPTION
## Purpose
The password of the superuser should be defined in a more dynamic way.

## Approach
- When it's in the debug mode and there's no superuser password defined, it uses the password `admin`
- When it's in the debug mode and a password was defined, a superuser with that password is created
- When it's not in the debug mode and a password isn't defined, no superuser is created
- When it's not in debug mode and a password is defined, a superuser with the defined password is created.

### Further Info
#211 