### PR TITLE
Store API specifications in the database

### DIFF
--- a/gateway/generator.py
+++ b/gateway/generator.py
@@ -1,8 +1,8 @@
 from drf_yasg import generators as drf_gen
 from drf_yasg import openapi
 
-from . import aggregator
-from . import utils
+from gateway import utils
+from gateway.aggregator import SwaggerAggregator
 
 
 class OpenAPISchemaGenerator(drf_gen.OpenAPISchemaGenerator):
@@ -22,7 +22,7 @@ class OpenAPISchemaGenerator(drf_gen.OpenAPISchemaGenerator):
                          'application/x-www-form-urlencoded',
                          'multipart/form-data'],
         }
-        sw_aggregator = aggregator.SwaggerAggregator(config_aggregator)
+        sw_aggregator = SwaggerAggregator(config_aggregator)
         swagger_spec = sw_aggregator.generate_swagger()
 
         endpoints = self.get_endpoints(request)

--- a/gateway/tests/fixtures.py
+++ b/gateway/tests/fixtures.py
@@ -2,6 +2,9 @@ import pytest
 
 import factories
 
+from core.tests.fixtures import logic_module
+from gateway.aggregator import SwaggerAggregator
+
 
 @pytest.fixture()
 def datamesh():
@@ -15,3 +18,13 @@ def datamesh():
                                       endpoint='/documents/', lookup_field_name='id')
     relationship = factories.Relationship(origin_model=lmm1, related_model=lmm2, key='documents')
     return lm1, lm2, relationship
+
+
+@pytest.fixture
+def aggregator(logic_module):
+    configuration = {
+        'apis': {
+            logic_module.endpoint_name: f'{logic_module.endpoint}/swagger.json'
+        }
+    }
+    return SwaggerAggregator(configuration)

--- a/gateway/tests/test_swagger_aggregator.py
+++ b/gateway/tests/test_swagger_aggregator.py
@@ -1,0 +1,63 @@
+import pytest
+
+from unittest.mock import Mock
+
+from gateway import utils
+from gateway.tests.fixtures import aggregator, logic_module
+
+
+@pytest.mark.django_db()
+class TestSwaggerAggregator:
+
+    def test_get_aggregate_swagger_without_api_specification(self, aggregator, logic_module, monkeypatch):
+        test_swagger = {'name': 'test'}
+        mocked_swagger = Mock(return_value=test_swagger)
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        result = aggregator.get_aggregate_swagger()
+        for api_name, api_url in aggregator.configuration['apis'].items():
+            assert api_name in result
+            assert result[api_name]['url'] == api_url
+            assert result[api_name]['spec'] == test_swagger
+
+        mocked_swagger.assert_called_once()
+
+    def test_get_aggregate_swagger_with_api_specification(self, aggregator, logic_module, monkeypatch):
+        test_swagger = {'name': 'test'}
+        logic_module.api_specification = test_swagger
+        logic_module.save()
+
+        mocked_swagger = Mock()
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        result = aggregator.get_aggregate_swagger()
+        for api_name, api_url in aggregator.configuration['apis'].items():
+            assert api_name in result
+            assert result[api_name]['url'] == api_url
+            assert result[api_name]['spec'] == test_swagger
+
+        mocked_swagger.assert_not_called()
+
+    def test_get_aggregate_swagger_connection_error(self, aggregator, logic_module, monkeypatch):
+        mocked_swagger = Mock(side_effect=ConnectionError)
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        result = aggregator.get_aggregate_swagger()
+        assert result == {}
+        mocked_swagger.assert_called_once()
+
+    def test_get_aggregate_swagger_timeout_error(self, aggregator, logic_module, monkeypatch):
+        mocked_swagger = Mock(side_effect=TimeoutError)
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        result = aggregator.get_aggregate_swagger()
+        assert result == {}
+        mocked_swagger.assert_called_once()
+
+    def test_get_aggregate_swagger_value_error(self, aggregator, logic_module, monkeypatch):
+        mocked_swagger = Mock(side_effect=ValueError)
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        result = aggregator.get_aggregate_swagger()
+        assert result == {}
+        mocked_swagger.assert_called_once()


### PR DESCRIPTION
## Purpose
Store service API specifications in the database, so they can be retrieved faster and used in the gateway routing.

## Approach
When API specifications are retrieved from services, they are stored in the *api_specification* field of each LogicModule.

### Further Info
Ticket number: #254 
