### PR TITLE
Create an endpoint to refresh API specifications

### DIFF
--- a/core/tests/test_logicmoduleview.py
+++ b/core/tests/test_logicmoduleview.py
@@ -1,7 +1,16 @@
+import pytest
 import factories
 
+from unittest.mock import Mock
+
 from django.test import TestCase
+from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
+
+from core.views.logicmodule import LogicModuleViewSet
+from core.tests.fixtures import logic_module, superuser
+
+from gateway import utils
 
 
 class LogicModuleViewsPermissionTest(TestCase):
@@ -38,3 +47,25 @@ class LogicModuleViewsPermissionTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get('content-type'), 'application/json')
         self.assertIsInstance(response.content, bytes)
+
+
+@pytest.mark.django_db()
+class TestLogicModuleUpdate:
+
+    def test_logic_module_update_api_specification(self, request_factory, superuser, logic_module, monkeypatch):
+        mocked_url = Mock(return_value='example.com')
+        test_swagger = {'name': 'example'}
+        mocked_swagger = Mock()
+        mocked_swagger.return_value.json.return_value = test_swagger
+
+        monkeypatch.setattr(utils, 'get_swagger_url_by_logic_module', mocked_url)
+        monkeypatch.setattr(utils, 'get_swagger_from_url', mocked_swagger)
+
+        request = request_factory.put(reverse('logicmodule-update-api-specification', args=(logic_module.pk,)))
+        request.user = superuser
+        view = LogicModuleViewSet.as_view({'put': 'update_api_specification'})
+        response = view(request, pk=logic_module.pk)
+        assert response.status_code == 200
+
+        logic_module.refresh_from_db()
+        assert logic_module.api_specification == test_swagger

--- a/core/views/logicmodule.py
+++ b/core/views/logicmodule.py
@@ -1,12 +1,16 @@
 import logging
 
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsSuperUser
 from core.models import LogicModule
 from core.serializers import LogicModuleSerializer
+
+from gateway import utils
 
 logger = logging.getLogger(__name__)
 
@@ -39,3 +43,28 @@ class LogicModuleViewSet(viewsets.ModelViewSet):
     permission_classes = (IsSuperUser,)
     queryset = LogicModule.objects.all()
     serializer_class = LogicModuleSerializer
+
+    @action(methods=['PUT'], url_path='specification', detail=True)
+    def update_api_specification(self, request, *args, **kwargs):
+        """
+        Updates the API specification of given logic module
+        """
+        instance = self.get_object()
+        schema_url = utils.get_swagger_url_by_logic_module(instance)
+
+        response = utils.get_swagger_from_url(schema_url)
+        spec_dict = response.json()
+        data = {
+            'api_specification': spec_dict
+        }
+
+        serializer = self.get_serializer(instance, data=data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        if getattr(instance, '_prefetched_objects_cache', None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        return Response(serializer.data)


### PR DESCRIPTION
## Purpose
Create an endpoint that will trigger the gathering of the API specification of a given service and replace the old one.

### Further Info
Ticket number: #256 