### PR TITLE
Add configuration for test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+  manage.py
+  conftest.py
+  */tests/*
+  */test_*
+  */migrations/*
+  */settings/*
+  */wsgi.py
+  */virtualenv/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
   - flake8
   - bandit -r . -ll
-  - pytest --cache-clear
+  - pytest --cov-config=.coveragerc --cache-clear
   - docker build -t $DOCKER_REPO .
 env:
   global:


### PR DESCRIPTION
## Purpose
In order to provide real information about the test coverage, we need to add some extra configuration. Specially, when the coverage is running on Travis CI.
