### PR TITLE
Replace buildly-ui to buildly-react-template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 	<ul>
 	  <li><a href="https://buildly-core.readthedocs.io/en/latest/">Buildly Documentation</a></li>
 	  <li><a href="https://swagger.io/specification/">OpenAPI Specification</a></li>
-	  <li><a href="https://github.com/buildlyio/buildly-ui">Get Buildly UI and administer your gateway the easy way</a></li>
+	  <li><a href="https://github.com/buildlyio/buildly-react-template">Get Buildly React Template and administer your gateway the easy way</a></li>
 	</ul>
 	<hr/>
 	<ul>


### PR DESCRIPTION
## Purpose
Change buildly-ui to buildly-react-template 

## Approach
I found out the link at buildly-core main page I missed changing names of buildly-ui to buildly-react-template inside /templates/index.html

### Further Info
Ticket number: 
 
@jefmoura 