### PR TITLE
Bump django-oauth-toolkit from 1.3.0 to 1.3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.5.2#egg=django-oaut
 djangorestframework==3.9.4
 psycopg2-binary==2.8.3
 social-auth-app-django==3.1.0
-django-oauth-toolkit==1.3.0
+django-oauth-toolkit==1.3.2
 futures==3.1.1
 django-cors-headers==2.5.3
 pyswagger==0.8.39


### PR DESCRIPTION
## Purpose
Fix wrong error message when trying to authenticate with wrong credentials.

## Approach
Upgrade the version of django-oauth-toolkit lib

### Further Info
Ticket number: #318 
